### PR TITLE
Add setup_package.py to allow 'python setup.py test' to work

### DIFF
--- a/linetools/spectra/setup_package.py
+++ b/linetools/spectra/setup_package.py
@@ -1,0 +1,9 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+
+def get_package_data():
+    return {'linetools.spectra.tests': ['files/*']}
+
+
+def requires_2to3():
+    return False


### PR DESCRIPTION
Adds a setup_package.py file to spectra/, which is needed to install the test data in linetools/spectra/tests/files.  This allows testing with 'python setup.py test'.