### PR TITLE
Change to fix build failure

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,6 +10,7 @@ recursive-include docs *
 recursive-include licenses *
 recursive-include cextern *
 recursive-include scripts *
+recursive-include linetools/data *
 
 prune build
 prune docs/_build

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ package_info = get_package_info()
 
 # Add the project-global data
 package_info['package_data'].setdefault(PACKAGENAME, [])
-package_info['package_data'][PACKAGENAME].append('data/*')
 
 # Define entry points for command-line scripts
 entry_points = {}


### PR DESCRIPTION
`python setup.py install` was failing due to peculiarities with setup.py pattern matching the 'linetools/data/lines' directory. This is a fix.