### PR TITLE
Fix bug in setwave, add warning, add tests

### DIFF
--- a/linetools/spectra/io.py
+++ b/linetools/spectra/io.py
@@ -262,16 +262,20 @@ def setwave(hdr):
     # Parse the header
     npix = hdr['NAXIS1'] 
     crpix1 = hdr['CRPIX1'] if 'CRPIX1' in hdr else 1.
-    crval1 = hdr['CRVAL1'] if 'CRVAL1' in hdr else 1.
-    cdelt1 = hdr['CDELT1'] if 'CDELT1' in hdr else 1.
-    ctype1 = hdr['CTYPE1'] if 'CTYPE1' in hdr else None
+    crval1 = hdr['CRVAL1']
+    cdelt1 = hdr['CDELT1']
     dcflag = hdr['DC-FLAG'] if 'DC-FLAG' in hdr else None
 
-    # Generate
-    if (dcflag == 1) or (cdelt1 < 1e-4):
-        wave = 10.**(crval1 + ( cdelt1 * np.arange(npix) + 1. - crpix1) ) # Log
+    if cdelt1 < 1e-4:
+        import warnings
+        warnings.warn('WARNING: CDELT1 < 1e-4, Assuming log wavelength scale')
+        dcflag = 1
 
-    # Return
+    # Generate
+    wave = crval1 + cdelt1 * (np.arange(npix) + 1. - crpix1)
+    if dcflag == 1:
+        wave = 10.**wave # Log
+
     return wave
 
 #### ###############################

--- a/linetools/spectra/tests/test_read_fits_spec.py
+++ b/linetools/spectra/tests/test_read_fits_spec.py
@@ -4,6 +4,7 @@ import pytest
 import astropy.io.ascii as ascii
 from astropy import units as u
 import numpy as np
+from astropy.io import fits
 
 from linetools.spectra import io
 
@@ -20,4 +21,12 @@ def test_sep_files():
     np.testing.assert_allclose(spec.sig, idl['sig'], atol=1e-3, rtol=0)
 
     assert spec.dispersion.unit == u.Unit('AA')
+
+def test_setwave():
+    hd = fits.getheader(data_path('UM184_nF.fits'))
+    wave = io.setwave(hd)
+    np.testing.assert_allclose(wave[0], 3042.34515916)
+    hd['CRPIX1'] = 10
+    wave = io.setwave(hd)
+    np.testing.assert_allclose(wave[0], 3040.33648468)
 


### PR DESCRIPTION
This fixes a bug (I think - please check carefully) in `setwave`, adds a warning if we guess the wavelengths are log, and adds a new test.  It also removes the assumption that `CRVAL1` and `CDELT1` are 1 if they aren't in the header, which seems a bad idea to me.