### PR TITLE
Add basic interactive plotting

### DIFF
--- a/linetools/analysis/interactive_plot.py
+++ b/linetools/analysis/interactive_plot.py
@@ -1,0 +1,189 @@
+""" Classes useful for making interactive plots.
+"""
+from __future__ import division, print_function, unicode_literals, absolute_import
+
+import os
+import numpy as np
+from ..utils import between
+from ..spectra.convolve import convolve_psf
+from ..spectra.plotting import get_flux_plotrange
+from .interp import AkimaSpline
+
+from astropy.modeling import models
+import astropy.units as u
+
+import matplotlib.transforms as mtran
+import matplotlib.pyplot as plt
+
+class PlotWrapBase(object):
+    """ A base class that has all the navigation and smoothing
+    keypress events.
+
+    These attributes must be defined in a subclass:
+
+    self.wa, self.fl    Spectrum wavelength and flux
+    self.nsmooth        integer > 0 that determines the smoothing
+    self.ax             Axes where spectrum is plotted
+    self.fig            Figure which holds the axes.
+    self.artists['fl']  The Matplotlib line artist that represents the flux.
+
+
+    The keypress events need to be connected to the figure with
+    something like:
+
+    def connect(self, fig):
+        cids = dict(key=[])
+        # the top two are methods of PlotWrapBase
+        cids['key'].append(fig.canvas.mpl_connect(
+            'key_press_event', self.on_keypress_navigate))
+        cids['key'].append(fig.canvas.mpl_connect(
+            'key_press_event', self.on_keypress_smooth))
+        self.cids.update(cids)
+    """
+    _help_string = """
+i,o          Zoom in/out x limits
+y            Zoom out y limits
+Y            Guess y limits
+t,b          Set y top/bottom limit
+l,r          Set left/right x limit
+[,]          Pan left/right
+w            Plot the whole spectrum
+
+S,U          Smooth/unsmooth spectrum
+"""
+
+    def __init__(self):
+        pass
+
+    def on_keypress_navigate(self, event):
+        """ Process a keypress event. Requires attributes self.ax,
+        self.fl, self.wa, self.fig
+        """
+        # Navigation
+        if event.key == 'i' and event.inaxes:
+            x0,x1 = self.ax.get_xlim()
+            x = event.xdata
+            dx = abs(x1 - x0)
+            self.ax.set_xlim(x - 0.275*dx, x + 0.275*dx)
+            self.fig.canvas.draw()
+        elif event.key == 'o' and event.inaxes:
+            x0,x1 = self.ax.get_xlim()
+            x = event.xdata
+            dx = abs(x1 - x0)
+            self.ax.set_xlim(x - 0.95*dx, x + 0.95*dx)
+            self.fig.canvas.draw()
+        elif event.key == 'Y' and event.inaxes:
+            y0,y1 = self.ax.get_ylim()
+            y = event.ydata
+            dy = abs(y1 - y0)
+            self.ax.set_ylim(y0 - 0.05*dy, y1 + 0.4*dy)
+            self.fig.canvas.draw()
+        elif event.key == 'y' and event.inaxes:
+            x0,x1 = self.ax.get_xlim()            
+            y0,y1 = get_flux_plotrange(self.fl[between(self.wa, x0, x1)])
+            self.ax.set_ylim(y0, y1)
+            self.fig.canvas.draw()
+        elif event.key == ']':
+            x0,x1 = self.ax.get_xlim()
+            dx = abs(x1 - x0)
+            self.ax.set_xlim(x1 - 0.1*dx, x1 + 0.9*dx)
+            self.fig.canvas.draw()
+        elif event.key == '[':
+            x0,x1 = self.ax.get_xlim()
+            dx = abs(x1 - x0)
+            self.ax.set_xlim(x0 - 0.9*dx, x0 + 0.1*dx)
+            self.fig.canvas.draw()
+        elif event.key == 'w':
+            self.ax.set_xlim(self.wa[0], self.wa[-1])
+            y0,y1 = get_flux_plotrange(self.fl)
+            self.ax.set_ylim(y0, y1)
+            self.fig.canvas.draw()
+        elif event.key == 'b' and event.inaxes:
+            y0, y1 = self.ax.get_ylim()
+            self.ax.set_ylim(event.ydata, y1)
+            self.fig.canvas.draw()
+        elif event.key == 't' and event.inaxes:
+            y0, y1 = self.ax.get_ylim()
+            self.ax.set_ylim(y0, event.ydata)
+            self.fig.canvas.draw()
+        elif event.key == 'l' and event.inaxes:
+            x0, x1 = self.ax.get_xlim()
+            self.ax.set_xlim(event.xdata, x1)
+            self.fig.canvas.draw()
+        elif event.key == 'r' and event.inaxes:
+            x0, x1 = self.ax.get_xlim()
+            self.ax.set_xlim(x0, event.xdata)
+            self.fig.canvas.draw()
+
+    def on_keypress_smooth(self, event):
+        """ Smooth the flux with a gaussian. Requires attributes
+        self.fl and self.nsmooth, self.artists['fl'] and self.fig."""
+
+        # maybe should use boxcar smoothing?
+        if event.key == 'S':
+            if self.nsmooth > 0:
+                self.nsmooth += 0.5
+            else:
+                self.nsmooth += 1
+            sfl = convolve_psf(self.fl, self.nsmooth)
+            self.artists['fl'].set_ydata(sfl)
+            self.fig.canvas.draw()
+        elif event.key == 'U':
+            self.nsmooth = 0
+            self.artists['fl'].set_ydata(self.fl)
+            self.fig.canvas.draw()
+
+class PlotWrapNav(PlotWrapBase):
+    """ Enable simple XIDL-style navigation for plotting a spectrum.
+
+    For example, i and o for zooming in y direction, [ and ] for
+    panning, S and U for smoothing and unsmoothing.
+    """
+    def __init__(self, fig, ax, wa, fl, artists):
+        """
+        Parameters
+        ----------
+        fig : matplotlib Figure
+        ax : matplotlib axes
+          The Axes where the spectrum is plotted.
+        wa, fl : array
+          Wavelength and flux arrays
+        artists : dict
+          A dictionary which must contain a key 'fl', which is the
+          matplotlib artist corresponding to the flux line.
+        """ 
+        self.artists = artists
+        self.fig = fig
+        self.ax = ax
+        if isinstance(wa, u.Quantity):
+            wa = wa.value
+        self.wa = wa
+        if isinstance(fl, u.Quantity):
+            fl = fl.value
+        self.fl = fl
+        self.nsmooth = 0
+        # disable existing keypress events (like 's' for save).
+        cids = list(fig.canvas.callbacks.callbacks['key_press_event'])
+        for cid in cids:
+            fig.canvas.callbacks.disconnect(cid)
+        self.cids = {}
+        self.connect()
+        print(self._help_string)
+
+
+    def on_keypress(self, event):
+        """ Print a help message"""
+        if event.key == '?':
+            print(self._help_string)
+
+    def connect(self):
+        cids = dict(key=[])
+        # the top two are methods of PlotWrapBase
+        cids['key'].append(self.fig.canvas.mpl_connect(
+            'key_press_event', self.on_keypress))
+        cids['key'].append(self.fig.canvas.mpl_connect(
+            'key_press_event', self.on_keypress_navigate))
+        cids['key'].append(self.fig.canvas.mpl_connect(
+            'key_press_event', self.on_keypress_smooth))
+        self.cids.update(cids)
+

--- a/linetools/spectra/io.py
+++ b/linetools/spectra/io.py
@@ -244,7 +244,7 @@ def readspec(specfil, inflg=None, efil=None, verbose=False, flux_tags=None,
         xspec1d = XSpectrum1D.from_array(uwave, u.Quantity(fx),
                                          uncertainty=StdDevUncertainty(sig))
 
-    xspec1d.filename = specfil
+    xspec1d.meta['filename'] = specfil
 
     if not hasattr(xspec1d, 'co'):
         xspec1d.co = co

--- a/linetools/spectra/xspectrum1d.py
+++ b/linetools/spectra/xspectrum1d.py
@@ -220,16 +220,19 @@ class XSpectrum1D(Spectrum1D):
     # Quick plot
     def plot(self, **kwargs):
         ''' Plot the spectrum
-
-        Parameters
-        ----------
         '''
         import matplotlib.pyplot as plt
+        from ..analysis.interactive_plot import PlotWrapNav
+
         ax = plt.gca()
+        fig = plt.gcf()
+
+        artists = {}
+        ax.axhline(0, color='k', lw=0.5)
 
         kwargs.update(color='0.6')
-        ax.plot(self.dispersion, self.flux, drawstyle='steps-mid',
-                **kwargs)
+        artists['fl'] = ax.plot(self.dispersion, self.flux,
+                                drawstyle='steps-mid', **kwargs)[0]
 
         if self.sig is not None:
             kwargs.update(color='g')
@@ -240,7 +243,20 @@ class XSpectrum1D(Spectrum1D):
 
         ax.set_ylim(*get_flux_plotrange(self.flux))
         ax.set_xlim(self.dispersion.value[0], self.dispersion.value[-1])
-        plt.show()
+
+
+        if plt.get_backend() == 'MacOSX':
+            import warnings
+            warnings.warn("""\
+Looks like you're using the MacOSX matplotlib backend. Switch to the TkAgg
+or QtAgg backends to enable all interactive plotting commands.
+""")
+        else:
+            # Enable xspecplot-style navigation (i/o for zooming, etc).
+            # Need to save this as an attribute so it doesn't get
+            # garbage-collected.
+            self._plotter = PlotWrapNav(fig, ax, self.dispersion,
+                                        self.flux, artists)
 
     #  Rebin
     def rebin(self, new_wv):
@@ -508,4 +524,3 @@ class XSpectrum1D(Spectrum1D):
         # Write
         hdu.writeto(outfil, clobber=clobber)
         print('Wrote spectrum to {:s}'.format(outfil))
-


### PR DESCRIPTION
This adds basic classes to allow adding commands for interactive plotting.  XSpectrum1D.plot is tweaked enable XIDL-style keypress navigation, which I much prefer to the standard matplotlib navigation tools.

I plan to extend this with an interactive continuum fitting class soon.

Any comments welcome!