### PR TITLE
spectra/convolve.py: barak convolution routines replaced by astropy.c…

### DIFF
--- a/linetools/spectra/convolve.py
+++ b/linetools/spectra/convolve.py
@@ -1,7 +1,7 @@
 """ Functions related to convolution.
       Taken from Barak by JXP
       May replace with scipy functions
-      NT: replace barak routines with astropy.convolvolution equivalents
+      NT: replace barak routines with astropy.convolution equivalents
 """ 
 
 # py2.6+ compatibility

--- a/linetools/spectra/convolve.py
+++ b/linetools/spectra/convolve.py
@@ -1,14 +1,16 @@
 """ Functions related to convolution.
       Taken from Barak by JXP
       May replace with scipy functions
+      NT: replace barak routines with astropy.convolvolution equivalents
 """ 
 
 # py2.6+ compatibility
 from __future__ import print_function, absolute_import, division, unicode_literals
 
 import numpy as np
+from astropy.convolution import convolve, Gaussian1DKernel, CustomKernel
 
-def convolve_psf(a, fwhm, edge='invert', replace_nan=False, debug=False):
+def convolve_psf_old(a, fwhm, edge='invert', replace_nan=False, debug=False):
     """ Convolve an array with a gaussian window.
 
     Given an array of values `a` and a gaussian full width at half
@@ -52,7 +54,7 @@ def convolve_psf(a, fwhm, edge='invert', replace_nan=False, debug=False):
 
     return convolve_window(a, gauss, edge=edge)
 
-def convolve_window(a, window, edge='invert'):
+def convolve_window_old(a, window, edge='invert'):
     """ Convolve an array with an arbitrary window.
 
     Parameters
@@ -106,3 +108,99 @@ def convolve_window(a, window, edge='invert'):
     temp2 = np.convolve(np.concatenate(temp1), window, mode=str('same'))
 
     return temp2[n:-n]
+
+
+#Updated functions using astropy.convolution
+def convolve_psf(array, fwhm, boundary='fill', fill_value=0., normalize_kernel=False):
+    """ Convolve an array with a gaussian kernel.
+
+    Given an array of values `a` and a gaussian full width at half
+    maximum `fwhm` in pixel units, returns the convolution of the
+    array with the gaussian kernel.
+
+    Parameters
+    ----------
+    array : array, shape(N,)
+        Array to convolve
+    fwhm : float
+        Gaussian full width at half maximum in pixels.
+    boundary : str, optional
+        A flag indicating how to handle boundaries:
+            * `None`
+                Set the ``result`` values to zero where the kernel
+                extends beyond the edge of the array (default).
+            * 'fill'
+                Set values outside the array boundary to ``fill_value``.
+            * 'wrap'
+                Periodic boundary that wrap to the other side of ``array``.
+            * 'extend'
+                Set values outside the array to the nearest ``array``
+                value.
+    fill_value : float, optional
+        The value to use outside the array when using boundary='fill'
+    normalize_kernel : bool, optional
+        Whether to normalize the kernel prior to convolving
+
+    Returns
+    -------
+    convolved_array : array, shape (N,)
+    
+    Notes
+    -----
+    This function uses astropy.convolution 
+    """
+
+    const2   = 2.354820046             # 2*sqrt(2*ln(2))
+    const100 = 3.034854259             # sqrt(2*ln(100))
+    sigma = fwhm / const2
+    # gaussian drops to 1/100 of maximum value at x =
+    # sqrt(2*ln(100))*sigma, so number of pixels to include from
+    # centre of gaussian is:
+    n = np.ceil(const100 * sigma)
+    x_size = int(2*n) + 1 # we want this to be odd integer
+    return convolve(array, Gaussian1DKernel(sigma,x_size=x_size),boundary=boundary,fill_value=fill_value,normalize_kernel=normalize_kernel)
+
+def convolve_window(array, window, boundary='fill', fill_value=0., normalize_kernel=True):
+    """ Convolve an array with an arbitrary window kernel.
+
+    Parameters
+    ----------
+    array : array, shape (N,)
+        Array to convolve
+    window : array, shape (M,)
+        The window array must have an odd number of elements.
+    boundary : str, optional
+        A flag indicating how to handle boundaries:
+            * `None`
+                Set the ``result`` values to zero where the kernel
+                extends beyond the edge of the array (default).
+            * 'fill'
+                Set values outside the array boundary to ``fill_value``.
+            * 'wrap'
+                Periodic boundary that wrap to the other side of ``array``.
+            * 'extend'
+                Set values outside the array to the nearest ``array``
+                value.
+    fill_value : float, optional
+        The value to use outside the array when using boundary='fill'
+    normalize_kernel : bool, optional
+        Whether to normalize the kernel prior to convolving
+
+    Returns
+    -------
+    convolved_array : array, shape (N,)
+    
+    Notes
+    -----
+    This function uses astropy.convolution, and astropy.modeling
+
+    If window kernel is as large or larger than the array, it raises an error.
+
+    """
+    if not len(window) % 2:
+        raise ValueError('`window` must have an odd number of elements!')
+
+    if len(window) >= len(array):
+        raise ValueError('`window` is too big for the `array`!')
+
+    return convolve(array, CustomKernel(window),boundary=boundary,fill_value=fill_value,normalize_kernel=normalize_kernel)

--- a/linetools/spectra/tests/test_xspectrum_utils.py
+++ b/linetools/spectra/tests/test_xspectrum_utils.py
@@ -42,7 +42,7 @@ def test_gauss_smooth():
     # Smooth
     smth_spec = spec.gauss_smooth(4.)
     # Test
-    np.testing.assert_allclose(smth_spec.flux[3000].value, 0.8288972218574113)
+    np.testing.assert_allclose(smth_spec.flux[3000].value, 0.8288110494613)
     assert smth_spec.flux.unit == spec.flux.unit
 
 # Rebin


### PR DESCRIPTION
spectra/convolve.py: barak convolution routines replaced by astropy.convolution equivalents.