### PR TITLE
Add plt.show to XSpectrum1D.plot

### DIFF
--- a/linetools/spectra/xspectrum1d.py
+++ b/linetools/spectra/xspectrum1d.py
@@ -226,6 +226,17 @@ class XSpectrum1D(Spectrum1D):
     # Quick plot
     def plot(self, **kwargs):
         ''' Plot the spectrum
+
+        Parameters
+        ----------
+        show : bool
+          If True (the default), then run the matplotlib.pyplot show
+          command to display the plot. Disable this if you are running
+          from a script and wish to delay showing the plot.
+
+        Other keyword arguments are passed to the matplotlib plot
+        command.
+
         '''
         import matplotlib.pyplot as plt
         from ..analysis.interactive_plot import PlotWrapNav
@@ -235,6 +246,8 @@ class XSpectrum1D(Spectrum1D):
 
         artists = {}
         ax.axhline(0, color='k', lw=0.5)
+
+        show = kwargs.pop('show', True)
 
         kwargs.update(color='0.6')
         artists['fl'] = ax.plot(self.dispersion, self.flux,
@@ -264,6 +277,9 @@ or QtAgg backends to enable all interactive plotting commands.
             # garbage-collected.
             self._plotter = PlotWrapNav(fig, ax, self.dispersion,
                                         self.flux, artists, printhelp=False)
+
+            if show:
+                plt.show()
 
     #  Rebin
     def rebin(self, new_wv):


### PR DESCRIPTION
This adds a `matplotlib.pyplot.show()` command to XSpectrum1D.plot so that the plot will always appear automatically, even when running from a script. This can be disabled with a new show keyword.