### PR TITLE
Make compatible with Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,8 @@ matrix:
     include:
 
         # Do a coverage test in Python 2.
-        - python: 2.7
-          env: SETUP_CMD='test --coverage'
+        #- python: 2.7
+        #  env: SETUP_CMD='test --coverage'
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
     #- 2.6
     - 2.7
     #- 3.3
-    #- 3.4
+    - 3.4
     # This is just for "egg_info".  All other builds are explicitly given in the matrix
 env:
     global:
@@ -43,8 +43,8 @@ matrix:
           env: SETUP_CMD='test'
         #- python: 3.3
         #  env: SETUP_CMD='test'
-        #- python: 3.4
-        #  env: SETUP_CMD='test'
+        - python: 3.4
+          env: SETUP_CMD='test'
 
         # Try older numpy versions. Skip these, because the require astroy versions < 1.0
         #- python: 2.7

--- a/linetools/__init__.py
+++ b/linetools/__init__.py
@@ -1,4 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+from __future__ import print_function, absolute_import, division, unicode_literals
+
 
 """
 This is an Astropy affiliated package.
@@ -14,5 +16,5 @@ from ._astropy_init import *
 if not _ASTROPY_SETUP_:
     pass
     #from example_mod import *
-    import spectra
-    import lists
+    from . import spectra
+    from . import lists

--- a/linetools/analysis/__init__.py
+++ b/linetools/analysis/__init__.py
@@ -1,1 +1,2 @@
-import utils
+from __future__ import print_function, absolute_import, division, unicode_literals
+from . import utils

--- a/linetools/analysis/continuum.py
+++ b/linetools/analysis/continuum.py
@@ -91,7 +91,7 @@ def linear_co(wa, knots):
 
     Add extra points on either end to give
     a nice slope at the end points."""
-    wavc, mfl = zip(*knots)[:2]
+    wavc, mfl = list(zip(*knots))[:2]
     extwavc = ([wavc[0] - (wavc[1] - wavc[0])] + list(wavc) +
                [wavc[-1] + (wavc[-1] - wavc[-2])])
     extmfl = ([mfl[0] - (mfl[1] - mfl[0])] + list(mfl) +
@@ -191,7 +191,7 @@ def prepare_knots(wa, fl, er, edges, ax=None, debug=False):
     update_knots(knots, indices, fl, masked)
 
     if ax is not None:
-        x,y = zip(*knots)[:2]
+        x,y = list(zip(*knots))[:2]
         ax.plot(x, y, 'o', mfc='none', mec='c', ms=10, mew=1, zorder=10)
 
     return knots, indices, masked
@@ -232,7 +232,7 @@ def estimate_continuum(s, knots, indices, masked, ax=None, maxiter=1000,
         model_a = Akima_co(s.wa, knots)
         chisq_chunk(model_a, s.fl, s.er, masked,
                     indices, knots, chithresh=1)
-        flags = zip(*knots)[-1]
+        flags = list(zip(*knots))[-1]
         if np.all(flags):
             if debug:
                 print('All regions have satisfactory fit, stopping')
@@ -259,7 +259,7 @@ def estimate_continuum(s, knots, indices, masked, ax=None, maxiter=1000,
     if ax is not None:
         ax.plot(s.wa, linear_co(s.wa, knots), color='0.7', lw=2)
         ax.plot(s.wa, co, 'k', lw=2, zorder=10)
-        x,y = zip(*knots)[:2]
+        x,y = list(zip(*knots))[:2]
         ax.plot(x, y, 'o', mfc='none', mec='k', ms=10, mew=1, zorder=10)
 
     return co

--- a/linetools/lists/__init__.py
+++ b/linetools/lists/__init__.py
@@ -1,2 +1,3 @@
-import linelist
-import parse
+from __future__ import print_function, absolute_import, division, unicode_literals
+from . import linelist
+from . import parse

--- a/linetools/lists/linelist.py
+++ b/linetools/lists/linelist.py
@@ -3,8 +3,14 @@ Module for LineList Class
 """
 from __future__ import print_function, absolute_import, division, unicode_literals
 
+# Python 2 & 3 compatibility
+try:
+    basestring
+except NameError:
+    basestring = str
+
 import numpy as np
-import os
+import os, imp
 import copy
 
 from astropy import units as u
@@ -48,7 +54,7 @@ class LineList(object):
         sort_subset=False):
 
         # Error catching
-        if not isinstance(llst_keys,(str,list,unicode)):
+        if not isinstance(llst_keys, (list, basestring)):
             raise TypeError('LineList__init__: Wrong type for LineList input')
 
         # Save
@@ -75,7 +81,7 @@ class LineList(object):
         """Grab the data for the lines of interest
         """
         # Import
-        reload(lilp)
+        imp.reload(lilp)
 
         # Define datasets: In order of Priority
         dataset = {

--- a/linetools/lists/parse.py
+++ b/linetools/lists/parse.py
@@ -5,8 +5,11 @@ Module for parsing Line List data
 from __future__ import print_function, absolute_import, division, unicode_literals
 
 import numpy as np
-import os, imp, glob, pdb, gzip
+import os, imp, glob, pdb, gzip, sys
 import subprocess
+if not sys.version_info[0] > 2:
+    import codecs
+    open = codecs.open
 
 from astropy import units as u
 from astropy.units.quantity import Quantity
@@ -306,7 +309,7 @@ def parse_morton03(orig=False, tab_fil=None, HIcombine=True):
         print(
             'linetools.lists.parse: Reading linelist --- \n   {:s}'.format(
                 morton03_tab2))
-        f = open(morton03_tab2, 'r')
+        f = open(morton03_tab2, 'r', encoding="ISO-8859-1")
         lines = f.readlines()
         f.close()
 

--- a/linetools/spectra/__init__.py
+++ b/linetools/spectra/__init__.py
@@ -1,2 +1,4 @@
+from __future__ import print_function, absolute_import, division, unicode_literals
+
 #import io
 #import utils

--- a/linetools/spectra/io.py
+++ b/linetools/spectra/io.py
@@ -5,6 +5,13 @@ Module for read/write of spectra FITS files
 
 from __future__ import print_function, absolute_import, division, unicode_literals
 
+# Python 2 & 3 compatibility
+try:
+    basestring
+except NameError:
+    basestring = str
+
+
 # Import libraries
 import numpy as np
 import os, pdb

--- a/linetools/spectra/lsf.py
+++ b/linetools/spectra/lsf.py
@@ -107,7 +107,7 @@ class LSF(object):
         # always the center value. Here we assume rel_pix are 
         # given in linear scale, which should be checked in load_XX_data()
 
-        n = len(rel_pix_array) / 2 #this should be always integer
+        n = len(rel_pix_array) // 2 #this should be always integer
         rel_pixel_array = np.arange(-n,n+1,1)
         self._data['rel_pix'] = rel_pixel_array
 

--- a/linetools/spectra/lsf.py
+++ b/linetools/spectra/lsf.py
@@ -1,7 +1,7 @@
 """
 Module for dealing with LSFs of various astronomical instruments.
 """
-from __future__ import print_function
+from __future__ import print_function, absolute_import, division, unicode_literals
 
 import numpy as np
 from scipy.interpolate import interp1d, Akima1DInterpolator

--- a/linetools/spectra/tests/test_lsf_init.py
+++ b/linetools/spectra/tests/test_lsf_init.py
@@ -1,4 +1,8 @@
 # Module to run tests on spectra.lsf
+
+from __future__ import print_function, absolute_import, \
+     division, unicode_literals
+
 import os
 import pytest
 from astropy import units as u
@@ -18,17 +22,17 @@ def test_lsf_COS():
             
             instr_config = dict(name='COS',grating=grating,life_position=lp)
             if lp == '2':
-            	if grating not in ['G130M','G160M']:
-            		continue
-            	if grating == 'G130M':
-            		cen_waves_aux = cen_waves_G130M
-            	elif grating == 'G160M':
-            		cen_waves_aux = cen_waves_G160M
+                if grating not in ['G130M','G160M']:
+                        continue
+                if grating == 'G130M':
+                        cen_waves_aux = cen_waves_G130M
+                elif grating == 'G160M':
+                        cen_waves_aux = cen_waves_G160M
 
-            	for cen_wave in cen_waves_aux:
-            		instr_config['cen_wave'] = cen_wave
-            		lsf = LSF(instr_config)
-            		print(lp,grating,cen_wave)
+                for cen_wave in cen_waves_aux:
+                        instr_config['cen_wave'] = cen_wave
+                        lsf = LSF(instr_config)
+                        print(lp,grating,cen_wave)
             elif lp == '1':
-				lsf = LSF(instr_config)
-				print(lp,grating)
+                lsf = LSF(instr_config)
+                print(lp,grating)

--- a/linetools/spectra/tests/test_lsf_use.py
+++ b/linetools/spectra/tests/test_lsf_use.py
@@ -1,4 +1,8 @@
 # Module to run tests on spectra.lsf
+from __future__ import print_function, absolute_import, \
+     division, unicode_literals
+
+
 import os
 import pytest
 import astropy.units as u
@@ -13,8 +17,8 @@ def test_interpolate_to_wv0(plot=False):
     cos_dict = dict(name='COS',grating='G130M',life_position='2',cen_wave='1309')
     lsf_cos = LSF(cos_dict)
     lsf_tab = lsf_cos.interpolate_to_wv0(wv0)
-    assert lsf_tab[len(lsf_tab)/2]['wv'] == wv0.value, err_msg
-    assert lsf_tab[len(lsf_tab)/2]['kernel'] == np.max(lsf_tab['kernel']), err_msg
+    assert lsf_tab[len(lsf_tab)//2]['wv'] == wv0.value, err_msg
+    assert lsf_tab[len(lsf_tab)//2]['kernel'] == np.max(lsf_tab['kernel']), err_msg
     if plot:
         import matplotlib.pyplot as plt
         wv_array = np.arange(1200,1400,10)*u.AA

--- a/linetools/spectra/tests/test_read_fits_spec.py
+++ b/linetools/spectra/tests/test_read_fits_spec.py
@@ -1,4 +1,7 @@
 # Module to run tests on spectra.io
+from __future__ import print_function, absolute_import, \
+     division, unicode_literals
+
 import os
 import pytest
 import astropy.io.ascii as ascii

--- a/linetools/spectra/tests/test_xspec_init.py
+++ b/linetools/spectra/tests/test_xspec_init.py
@@ -1,4 +1,6 @@
 # Module to run tests on spectra.io
+from __future__ import print_function, absolute_import, \
+     division, unicode_literals
 import os
 import pytest
 import astropy.io.ascii as ascii

--- a/linetools/spectra/tests/test_xspectrum_utils.py
+++ b/linetools/spectra/tests/test_xspectrum_utils.py
@@ -1,4 +1,6 @@
 # Module to run tests on spectra.io
+from __future__ import print_function, absolute_import, \
+     division, unicode_literals
 import os
 import pytest
 from astropy import units as u

--- a/linetools/spectra/xspectrum1d.py
+++ b/linetools/spectra/xspectrum1d.py
@@ -547,7 +547,7 @@ or QtAgg backends to enable all interactive plotting commands.
 
         # Deal with header
         if hasattr(self,'head'):
-            hdukeys = prihdu.header.keys()
+            hdukeys = list(prihdu.header.keys())
             # Append ones to avoid
             hdukeys = hdukeys + ['BUNIT','COMMENT','', 'NAXIS2', 'HISTORY']
             for key in self.head.keys():

--- a/linetools/spectralline.py
+++ b/linetools/spectralline.py
@@ -12,10 +12,16 @@
 """
 from __future__ import print_function, absolute_import, division, unicode_literals
 
+# Python 2 & 3 compatibility
+try:
+    basestring
+except NameError:
+    basestring = str
+
 import numpy as np
 import pdb
 from abc import ABCMeta, abstractmethod
-import copy
+import copy, imp
 
 from astropy import constants as const
 from astropy import units as u
@@ -213,7 +219,7 @@ class SpectralLine(object):
         self.attrib[ 'EW', 'sigEW' ] : 
           EW and error in observer frame
         """
-        reload(lau)
+        imp.reload(lau)
         # Cut spectrum
         fx, sig, xdict = self.cut_spec(normalize=True)
         wv = xdict['wave']
@@ -331,7 +337,7 @@ class AbsLine(SpectralLine):
         self.attrib[ 'N', 'sigN', 'logN', 'sig_logN' ]  
           Column densities and errors, linear and log
         """
-        reload(laa)
+        imp.reload(laa)
 
         # Cut spectrum
         fx, sig, xdict = self.cut_spec(normalize=True)

--- a/linetools/tests/test_absline_anly.py
+++ b/linetools/tests/test_absline_anly.py
@@ -1,6 +1,7 @@
 # Module to run tests on AbsLine analysis
 
 # TEST_UNICODE_LITERALS
+from __future__ import print_function, absolute_import, division, unicode_literals
 
 import numpy as np
 import os, pdb
@@ -18,12 +19,12 @@ def test_aodm_absline():
     # Init CIV 1548
     abslin = AbsLine(1548.195*u.AA)
 
-    # Set spectrum 
+    # Set spectrum
     abslin.analy['spec'] = lsio.readspec(data_path('UM184_nF.fits')) # Fumagalli+13 MagE spectrum
     abslin.analy['wvlim'] = [6080.78, 6087.82]*u.AA
-    # 
+    #
     abslin.measure_aodm()
-    N, sigN, flgN = [abslin.attrib[key] for key in ['N','sigN','flagN']] 
+    N, sigN, flgN = [abslin.attrib[key] for key in ['N','sigN','flagN']]
 
     np.testing.assert_allclose(N.value, 300009659372018.7)
     assert N.unit == 1/u.cm**2
@@ -35,25 +36,25 @@ def test_aodm_absline():
     abslin.attrib['z'] = 2.92929
     #
     abslin.measure_aodm()
-    N, sigN, flgN = [abslin.attrib[key] for key in ['N','sigN','flagN']] 
+    N, sigN, flgN = [abslin.attrib[key] for key in ['N','sigN','flagN']]
     np.testing.assert_allclose(N.value, 80369196079224.42)
 
 def test_boxew_absline():
     # Text boxcar EW evaluation
-	# Init CIV 1548
+        # Init CIV 1548
     abslin = AbsLine(1548.195*u.AA)
 
-    # Set spectrum 
+    # Set spectrum
     abslin.analy['spec'] = lsio.readspec(data_path('UM184_nF.fits')) # Fumagalli+13 MagE spectrum
     abslin.analy['wvlim'] = [6080.78, 6087.82]*u.AA
     # Measure EW (not rest-frame)
-    abslin.measure_ew() 
+    abslin.measure_ew()
     ew = abslin.attrib['EW']
 
     np.testing.assert_allclose(ew.value, 0.9935021012055584)
     assert ew.unit == u.AA
 
-    abslin.measure_restew() 
+    abslin.measure_restew()
     #import pdb
     #pdb.set_trace()
     np.testing.assert_allclose(ew.value, 0.9935021012055584/(1+abslin.attrib['z']))
@@ -63,7 +64,7 @@ def test_gaussew_absline():
     # Init CIV 1548
     abslin = AbsLine(1548.195*u.AA)
 
-    # Set spectrum 
+    # Set spectrum
     abslin.analy['spec'] = lsio.readspec(data_path('UM184_nF.fits')) # Fumagalli+13 MagE spectrum
     abslin.analy['wvlim'] = [6080.78, 6087.82]*u.AA
     # Measure EW (not rest-frame)
@@ -76,7 +77,7 @@ def test_gaussew_absline():
     abslin.measure_ew(flg=2,initial_guesses=(0.5,6081,1))
     np.testing.assert_allclose(ew.value, 1.02,atol=0.01)
 
-    abslin.measure_restew() 
+    abslin.measure_restew()
     np.testing.assert_allclose(ew.value, 1.02/(1+abslin.attrib['z']),atol=0.01)
 
 

--- a/linetools/tests/test_init_absline.py
+++ b/linetools/tests/test_init_absline.py
@@ -1,6 +1,7 @@
 # Module to run tests on initializing AbsLine
 
 # TEST_UNICODE_LITERALS
+from __future__ import print_function, absolute_import, division, unicode_literals
 
 import numpy as np
 import os, pdb


### PR DESCRIPTION
We need to be Python 3 compatible if we want to be taken seriously by the astropy crowd :)

Therefore, this PR makes the changes necessary for linetools to work with Python 3.  All the tests pass in Python 3.4, and hopefully (!) Travis will now run the test suite using that python version, in addition to Python 2.7.

Note that there may still be python 3-related incompatibilities that aren't shown up by our tests.