### PR TITLE
Update spectralline.py so Sphinx can parse docstrings

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,9 +1,8 @@
-================
+=================
 The linetools API
-================
+=================
 
-.. automodule:: spectralline
-    :members:
+.. automodapi:: linetools.spectralline
+		:skip: Quantity
+		:skip: LineList
 
-.. automodule:: utils
-    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,6 +79,9 @@ copyright = '{0}, {1}'.format(
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
+    'astropy_helpers.sphinx.ext.numpydoc',
+    'astropy_helpers.sphinx.ext.automodapi',
+    #'astropy_helpers.sphinx.ext',
 ]
 
 __import__(setup_cfg['package_name'])

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
    contain the root `toctree` directive.
 
 Welcome to the documentation for linetools!
-=================================
+===========================================
 
 linetools is an astropy-affiliated package developed to provide software
 related to 1D spectra (wavelength vs. flux) with emphasis on spectral line
@@ -21,31 +21,32 @@ Contents
    install
    api
 
-**Core classes**
+..
+   **Core classes**
 
-.. toctree::
-   :maxdepth: 1
+   .. toctree::
+      :maxdepth: 1
 
-   linelist
-   spectralline
-   xspectrum1d
+      linelist
+      spectralline
+      xspectrum1d
 
-**Methods and Scripts**
+   **Methods and Scripts**
 
-.. toctree::
-   :maxdepth: 1
+   .. toctree::
+      :maxdepth: 1
 
-   voigt
-   Scripts <scripts>
+      voigt
+      Scripts <scripts>
 
-**Project details**
+   **Project details**
 
-.. toctree::
-   :maxdepth: 1
+   .. toctree::
+      :maxdepth: 1
 
-   whatsnew
-   credits
-   license
+      whatsnew
+      credits
+      license
 
 
 Indices and tables

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -92,3 +92,25 @@ run::
 This takes a couple of minutes to run. If you notice any failures,
 we'd love you to report them on the `linetools issue tracker
 <http://github.com/linetools/linetools/issues>`_.
+
+
+Building Documentation
+======================
+
+Only do this if you're a developer! If you want build the
+documentation, you also need to install Sphinx (version 1.3+),
+astropy_helpers:
+
+  conda install sphinx
+  pip install astropy-helpers
+
+If you want generate inheritance diagrams, then you also need to
+install graphviz (`MacOSX
+<http://www.graphviz.org/Download_macos.php>`_, `Ubuntu
+<http://www.graphviz.org/Download_linux_ubuntu.php>`_), but this isn't
+required. Then change to the /docs directory under the source
+directory and run::
+
+  make html
+
+The documentation should now be in _build/html.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -13,7 +13,7 @@ Linetools depends on these packages:
 * `numpy <http://www.numpy.org/>`_ version 1.9 or later
 * `astropy <http://www.astropy.org>`_ version 1.0 or later
 * `scipy <http://www.scipy.org/>`_ version 0.16 or later
-* `matplotlib <http://matplotlib.org/>`_  version 2 or later
+* `matplotlib <http://matplotlib.org/>`_  version 1.4 or later
 * `pyyaml <http://pyyaml.org/wiki/PyYAML>`_ version 3.11 or later
 * `specutils <https://github.com/astropy/specutils>`_ version 0.2 or later
 
@@ -36,7 +36,7 @@ installed using `pip <https://pip.pypa.io/en/latest/>`_::
   
   pip install --no-deps specutils
 
-If you aren't using Anaconda then all of the dependencies can be
+If you aren't using Anaconda then all of the dependencies can also be
 installed with pip.
 
 
@@ -44,7 +44,8 @@ Installing Linetools
 ====================
 
 If you plan to play around with the code and possibly contribute
-changes, then follow the instructions below. Otherwise simply use::
+changes, then follow the instructions in the section below,
+:ref:`installsource`. Otherwise simply use::
 
     pip install --no-deps git+https://github.com/linetools/linetools.git
 
@@ -74,6 +75,20 @@ modules to see those changes in an existing Python session, though).
 
 Fantastic! In that case, follow the `Astropy developer guidelines
 <http://docs.astropy.org/en/stable/development/workflow/development_workflow.html>`_,
-, replacing every instance of `astropy` in those instructions with
+replacing every instance of `astropy` in those instructions with
 `linetools`. This will install a 'fork' of linetools that you can use
 to submit code changes to the main repository.
+
+
+Running Tests
+=============
+
+If you install linetools from source, then you can run tests to see
+whether your installation works correctly. From the source directory
+run::
+
+    python setup.py test
+
+This takes a couple of minutes to run. If you notice any failures,
+we'd love you to report them on the `linetools issue tracker
+<http://github.com/linetools/linetools/issues>`_.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -98,18 +98,18 @@ Building Documentation
 ======================
 
 Only do this if you're a developer! If you want build the
-documentation, you also need to install Sphinx (version 1.3+),
+documentation, you also need to install Sphinx (version 1.3+) and
 astropy_helpers::
 
   conda install sphinx
   pip install astropy-helpers
 
-If you want generate inheritance diagrams, then you also need to
-install graphviz (`MacOSX
+If you want the generate inheritance diagrams in the docs then you
+also need to install graphviz (`MacOSX
 <http://www.graphviz.org/Download_macos.php>`_, `Ubuntu
 <http://www.graphviz.org/Download_linux_ubuntu.php>`_), but this isn't
-required. Then change to the /docs directory under the source
-directory and run::
+required. Once you've installed the dependencies, change to the
+`/docs` directory under the source directory and run::
 
   make html
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -99,7 +99,7 @@ Building Documentation
 
 Only do this if you're a developer! If you want build the
 documentation, you also need to install Sphinx (version 1.3+),
-astropy_helpers:
+astropy_helpers::
 
   conda install sphinx
   pip install astropy-helpers

--- a/linetools/spectralline.py
+++ b/linetools/spectralline.py
@@ -1,14 +1,4 @@
-"""
-#;+ 
-#; NAME:
-#; spectralline
-#;    Version 1.0
-#;
-#; PURPOSE:
-#;    Module for SpectralLine class
-#;   23-Jun-2015 by JXP
-#;-
-#;------------------------------------------------------------------------------
+""" Classes for an emission or absorption spectral line
 """
 from __future__ import print_function, absolute_import, division, unicode_literals
 
@@ -19,58 +9,45 @@ except NameError:
     basestring = str
 
 import numpy as np
-import pdb
-from abc import ABCMeta, abstractmethod
-import copy, imp
+import copy
 
-from astropy import constants as const
 from astropy import units as u
 from astropy.units import Quantity
 
 from linetools.analysis import utils as lau
 from linetools.analysis import absline as laa
-from linetools.spectra import io as lsio
 from linetools.lists.linelist import LineList
-
-#import xastropy.atomic as xatom
-#from xastropy.stats import basic as xsb
-#from xastropy.xutils import xdebug as xdb
-
-# class SpectralLine(object):
-# class AbsLine(SpectralLine):
-# class AbsComponens(AbsLine):
 
 # Class for Spectral line
 class SpectralLine(object):
-    """Class for a spectral line.  Emission or absorption 
-
-    Attributes:
-        ltype: str
-          type of line, e.g.  Abs, Emiss
-        wrest : Quantity
-          Rest wavelength
-        z: float
-          Redshift
     """
-    __metaclass__ = ABCMeta
+    Class for a spectral line.  Emission or absorption.
+
+    Parameters
+    ----------
+    ltype : {'Abs'}
+      Type of Spectral line. Just 'Abs' for now (also 'Em' in future).
+    trans : Quantity or str
+      Either the rest wavelength (e.g. 1215.6700*u.AA) or the
+      transition name (e.g. 'CIV 1548')
+    linelist : LineList, optional
+      A LineList instance or string input to LineList (e.g. 'HI')
+    closest : bool [False]
+      Take the closest line to input wavelength.
+
+    Attributes
+    ----------
+    ltype : str
+      type of line, e.g.  Abs, Emiss
+    wrest : Quantity
+      Rest wavelength
+    z : float
+      Redshift
+    """
 
     # Initialize with wavelength
     def __init__(self, ltype, trans, linelist=None, closest=False,
         z=0.):
-        """  Initiator
-
-        Parameters
-        ----------
-        ltype : string
-          Type of Spectral line, 'Abs'
-        trans: Quantity or str
-          Quantity: Rest wavelength (e.g. 1215.6700*u.AA)
-          str: Name of transition (e.g. 'CIV 1548')
-        linelist : LineList, optional
-          Class of linelist or str setting LineList
-        closest : bool, optional
-          Take the closest line to input wavelength? [False]
-        """
 
         # Required
         self.ltype = ltype
@@ -82,7 +59,7 @@ class SpectralLine(object):
             raise ValueError('Rest wavelength must be a Quantity or str')
 
         # Other
-        self.data = {} # Atomic/Moleculare Data (e.g. f-value, A coefficient, Elow)
+        self.data = {} # Atomic/Molecular Data (e.g. f-value, A coefficient, Elow)
         self.analy = {'spec': None, # Analysis inputs (e.g. spectrum; from .clm file or AbsID)
             'wvlim': [0., 0.]*u.AA, # Wavelength interval about the line (observed)
             'vlim': [0., 0.]*u.km/u.s, # Velocity limit of line, relative to self.attrib['z']
@@ -98,32 +75,33 @@ class SpectralLine(object):
         # Fill data
         self.fill_data(trans, linelist=linelist, closest=closest)
 
-    def ismatch(self,inp,Zion=None,RADec=None):
+    def ismatch(self, inp, Zion=None, RADec=None):
         '''Query whether input line matches on:  z, Z, ion, RA, Dec
-        Parameters:
+
+        Parameters
         ----------
-        inp: SpectralLine or tuple
-          SpectralLine -- Other spectral line for comparison
-          tuple -- (z,wrest) float,Quantity
-             e.g. (1.3123, 1215.670*u.AA)
-        Zion: tuple of ints, optional
+        inp : SpectralLine or tuple
+          * SpectralLine -- Other spectral line for comparison
+          * tuple -- (z, wrest) float, Quantity
+            e.g. (1.3123, 1215.670*u.AA)
+        Zion : tuple of ints, optional
           Generally used with tuple input, e.g. (6,2)
-        RADec: tuple of Quantities, optional
+        RADec : tuple of Quantities, optional
           Generally used with tuple input e.g. (124.132*u.deg, 29.231*u.deg)
 
-        Returns:
+        Returns
         -------
-        answer: bool
+        answer : bool
           True if a match, else False
         '''
-        if isinstance(inp,SpectralLine):
+        if isinstance(inp, SpectralLine):
             wrest = inp.wrest
             z = inp.attrib['z']
             if Zion is None:
                 Zion = (inp.data['Z'], inp.data['ion'])
             if RADec is None:
                 RADec = (inp.attrib['RA'], inp.attrib['Dec'])
-        elif isinstance(inp,tuple):
+        elif isinstance(inp, tuple):
             z = inp[0]
             wrest = inp[1]
         else:
@@ -145,20 +123,20 @@ class SpectralLine(object):
         return answer
 
     def cut_spec(self, normalize=False, relvel=False):
-        '''Setup spectrum for analysis.  Splice.  Normalize too (as desired)
+        """ Cut out a chunk of the spectrum around this line.
 
-        Parameters:
+        Parameters
         ----------
-        normalize: bool, optional
-          Normalize if true (and continuum exists)
-        relvel: bool, optional
-          Calculate and return relative velocity [False]
+        normalize : bool [False]
+          Normalize the spectrum if true (and continuum exists)
+        relvel : bool [False]
+          Calculate and return velocity relative to this line
 
-        Returns:
-        ----------
-        fx, sig, dict(wave,velo) -- 
+        Returns
+        -------
+        fx, sig, dict(wave, velo)
           Arrays (numpy or Quantity) of flux, error, and wavelength/velocity
-        '''
+        """
         # Checks
         if self.analy['spec'] is None:
             raise ValueError('spectralline.cut_spec: Need to set spectrum!')
@@ -183,7 +161,7 @@ class SpectralLine(object):
 
         # Velocity array
         self.analy['spec'].velo = self.analy['spec'].relative_vel(
-            self.wrest*(1+self.attrib['z']))
+            self.wrest*(1 + self.attrib['z']))
         velo = self.analy['spec'].velo[pix] 
 
         # Normalize?
@@ -201,28 +179,26 @@ class SpectralLine(object):
 
     # EW 
     def measure_ew(self, flg=1, initial_guesses=None):
-        """EW calculation
-        Default is simple boxcar integration
-        Observer frame, not rest-frame (use measure_restew below)
-          wvlim must be set!
-          spec must be set!
+        """ Measure the observer frame equivalent width
+
+        Note this requires `wvlim` and `spec` attributes must be set!
+        Default is simple boxcar integration. Observer frame, not
+        rest-frame (use measure_restew below for rest-frame).
+
+        It sets the following attributes:
+           * self.attrib['EW'], self.attrib['sigEW']:
+             The EW and error in observer frame
 
         Parameters
         ----------
-        flg : int, optional
-          1-- Boxcar integration
-          2-- Gaussian fit
-        
-        initial_guesses, optional: tuple of floats
-          if a model is chosen (e.g. flg=2, Gaussian) a tuple of (amplitude, mean, stddev)
-          can be specified. 
+        flg : {1, 2} [1]
+          * 1 -- Boxcar integration 
+          * 2 -- Gaussian fit
+        initial_guesses : tuple of floats [None]
+          If a model is chosen (e.g. flg=2, Gaussian) a tuple of
+          (amplitude, mean, stddev) can be specified.
 
-        Fills
-        -----
-        self.attrib[ 'EW', 'sigEW' ]
-          EW and error in observer frame
         """
-        imp.reload(lau)
         # Cut spectrum
         fx, sig, xdict = self.cut_spec(normalize=True)
         wv = xdict['wave']
@@ -240,9 +216,10 @@ class SpectralLine(object):
         self.attrib['sigEW'] = sigEW 
 
     # EW 
-    def measure_restew(self,**kwargs):
-        """  Rest EW calculation
-        Return rest-frame.  See "measure_ew" above for details
+    def measure_restew(self, **kwargs):
+        """  Measure the rest-frame equivalent width
+
+        See `~measure_ew` for details.
         """
         # Standard call
         self.measure_ew(**kwargs)
@@ -265,11 +242,14 @@ class SpectralLine(object):
 # ###########################################
 # Class for Generic Absorption Line System
 class AbsLine(SpectralLine):
-    """Spectral absorption line
-    trans: Quantity or str
+    """Class representing a spectral absorption line.
+
+    Parameters
+    ----------
+    trans : Quantity or str
       Quantity: Rest wavelength (e.g. 1215.6700*u.AA)
-      str: Name of transition (e.g. 'CIV 1548')
-        [Note: for an unknown transition use string 'unknown']
+      str: Name of transition (e.g. 'CIV 1548'). For an unknown
+      transition use string 'unknown'.
     """
     # Initialize with a .dat file
     def __init__(self, trans, **kwargs):
@@ -277,22 +257,23 @@ class AbsLine(SpectralLine):
         SpectralLine.__init__(self,'Abs', trans, **kwargs)
 
     def print_specline_type(self):
-        """"Return a string representing the type of vehicle this is."""
+        """ Return a string representing the type of vehicle this is."""
         return 'AbsLine'
 
-    def fill_data(self,trans, linelist=None, closest=False):
-        ''' Fill atomic data and setup analy
-        Parameters:
-        -----------
-        trans: Quantity or str
-          Quantity: Rest wavelength (e.g. 1215.6700*u.AA)
-          str: Name of transition (e.g. 'CIV 1548')
-            [Note: for an unknown transition use string 'unknown']
+    def fill_data(self, trans, linelist=None, closest=False):
+        """ Fill atomic data and setup analy.
+
+        Parameters
+        ----------
+        trans : Quantity or str
+          Either a rest wavelength (e.g. 1215.6700*u.AA) or the name
+          of a transition (e.g. 'CIV 1548'). For an unknown transition
+          use string 'unknown'.
         linelist : LineList, optional
           Class of linelist or str setting LineList
         closest : bool, optional
           Take the closest line to input wavelength? [False]
-        '''
+        """
 
         # Deal with LineList
         if linelist is None:
@@ -329,22 +310,21 @@ class AbsLine(SpectralLine):
                        } )
     # Voigt
     def generate_voigt(self, wave=None, **kwargs):
-        """  Generate a Voigt profile model for the absorption line
-        in a given spectrum.
+        """ Generate a Voigt profile model for the absorption line in
+        a given spectrum.
 
-        Parameters:
+        Parameters
         ----------
-        wave: Quantity array
+        wave : Quantity array
           Wavelength array on which to calculate the line
           Must be set if self.analy['spec'] is not filled
 
-        Returns:
-        ----------
-        spec: XSpectrum1D
+        Returns
+        -------
+        spec : XSpectrum1D
           Spectrum with the input wavelength and the absorbed flux
         """
         from linetools.analysis import voigt as lav
-        reload(lav)
         # Checks
         if self.attrib['N'] < 1.:
             raise ValueError("Need to initialize log column density in attrib['N']")
@@ -363,19 +343,20 @@ class AbsLine(SpectralLine):
 
     # AODM
     def measure_aodm(self, nsig=3.):
-        """  AODM calculation
+        """ AODM calculation
+
         Parameters
         ----------
-        nsig: float, optional
+        nsig : float, optional
           Number of sigma significance required for a "detection"
 
-        Fills:
-        -------
+        Notes  
+        -----
+        Sets attributes:
+
         self.attrib[ 'N', 'sigN', 'logN', 'sig_logN' ]  
           Column densities and errors, linear and log
         """
-        imp.reload(laa)
-
         # Cut spectrum
         fx, sig, xdict = self.cut_spec(normalize=True)
         velo = xdict['velo']
@@ -423,19 +404,20 @@ class AbsLine(SpectralLine):
         return (txt)
 
 def many_abslines(all_wrest, llist):
-    '''Generate a list of AbsLine objects
-    Useful for when you have many lines (>1000) to generate
-    that have similar wrest.  Uses deepcopy
+    """Generate a list of AbsLine objects.
 
-    Parameters:
-    -----------
-    all_wrest: list of lines
-    llist: LineList
+    Useful for when you have many lines (>1000) to generate that have
+    similar wrest.  Uses deepcopy.
 
-    Returns:
+    Parameters
     ----------
-    abs_lines: list of AbsLine Objects
-    '''
+    all_wrest : list of lines
+    llist : LineList
+
+    Returns
+    -------
+    abs_lines : list of AbsLine Objects
+    """
     # Find unique lines
     wrestv =  np.array([iwrest.value for iwrest in all_wrest]) 
     uniq_wrest = np.unique( wrestv )

--- a/linetools/spectralline.py
+++ b/linetools/spectralline.py
@@ -185,8 +185,8 @@ class SpectralLine(object):
         Default is simple boxcar integration. Observer frame, not
         rest-frame (use measure_restew below for rest-frame).
 
-        It sets the following attributes:
-           * self.attrib['EW'], self.attrib['sigEW']:
+        It sets these attributes:
+           * self.attrib[ 'EW', 'sigEW' ]:
              The EW and error in observer frame
 
         Parameters
@@ -345,17 +345,14 @@ class AbsLine(SpectralLine):
     def measure_aodm(self, nsig=3.):
         """ AODM calculation
 
+        It sets these attributes:
+          * self.attrib[ 'N', 'sigN', 'logN', 'sig_logN' ]:
+            Column densities and errors, linear and log
+
         Parameters
         ----------
         nsig : float, optional
           Number of sigma significance required for a "detection"
-
-        Notes  
-        -----
-        Sets attributes:
-
-        self.attrib[ 'N', 'sigN', 'logN', 'sig_logN' ]  
-          Column densities and errors, linear and log
         """
         # Cut spectrum
         fx, sig, xdict = self.cut_spec(normalize=True)

--- a/linetools/spectralline.py
+++ b/linetools/spectralline.py
@@ -37,12 +37,18 @@ class SpectralLine(object):
 
     Attributes
     ----------
-    ltype : str
-      type of line, e.g.  Abs, Emiss
+    ltype : {'Abs', 'Emiss'}
+      type of line
     wrest : Quantity
       Rest wavelength
     z : float
       Redshift
+    attrib : dict
+      Line properties (e.g. column, EW, centroid, RA, Dec)
+    analy : dict
+      Analysis inputs (e.g. a spectrum, wavelength limits)
+    data : dict
+      Line atomic/molecular data ((e.g. f-value, A coefficient, Elow)
     """
 
     # Initialize with wavelength


### PR DESCRIPTION
This updates `spectralline.py` so that Sphinx will parse the docstrings correctly (according to the rules given at http://docs.astropy.org/en/stable/development/docrules.html). I suggest we use `spectralline.py` as a template for future docstrings.

You can see the result here: https://dl.dropboxusercontent.com/u/7970232/linetools_docs/index.html
(go to linetools API -> SpectralLine, for example).

I've also updated the installation docs with instructions on how to build the docs.