### PR TITLE
Add copy method (again)

### DIFF
--- a/linetools/spectra/tests/test_xspectrum_utils.py
+++ b/linetools/spectra/tests/test_xspectrum_utils.py
@@ -111,3 +111,7 @@ def test_readwrite_metadata(spec):
     np.testing.assert_allclose(spec2.meta['d'], d['d'])
     assert spec2.meta['e'] == d['e']
     
+def test_copy(spec):
+    spec2 = spec.copy()
+    assert spec.wavelength[0] == spec2.wavelength[0]
+    assert spec.flux[-1] == spec2.flux[-1]

--- a/linetools/spectra/xspectrum1d.py
+++ b/linetools/spectra/xspectrum1d.py
@@ -1,6 +1,4 @@
-"""
-Module for utilites related to spectra
-  -- Main item is a Class XSpectrum1D which overloads Spectrum1D
+"""Module containing the XSpectrum1D class which overloads Spectrum1D
 """
 from __future__ import print_function, absolute_import, division, unicode_literals
 
@@ -67,7 +65,11 @@ class XSpectrum1D(Spectrum1D):
 
     @classmethod
     def from_tuple(cls,ituple):
-        '''tuple -- (wave,flux) or (wave,flux,sig)
+        '''Make an XSpectrum1D from a tuple of arrays.
+
+        Parameters
+        ----------
+        ituple -- (wave,flux), (wave,flux,sig)
         If wave is unitless, Angstroms are assumed
         '''
         # Units
@@ -87,6 +89,22 @@ class XSpectrum1D(Spectrum1D):
                 uncertainty=StdDevUncertainty(ituple[2]))
         spec.filename = 'none'
         # Return
+        return spec
+
+    def copy(self):
+        flux = np.array(self.flux.value, copy=True)
+        uncer = StdDevUncertainty(self.uncertainty, copy=True)
+        mask = np.array(self.mask, copy=True)
+
+        # don't make a copy of the wcs. I think this should be ok...
+        spec = XSpectrum1D(flux=flux, wcs=self.wcs, unit=self.flux.unit,
+                   uncertainty=uncer, mask=mask,
+                   meta=self.meta.copy())
+        if hasattr(self, 'co'):
+            spec.co = self.co
+            if spec.co is not None:
+                spec.co = np.array(spec.co, copy=True)
+
         return spec
 
     @property

--- a/linetools/spectra/xspectrum1d.py
+++ b/linetools/spectra/xspectrum1d.py
@@ -69,8 +69,8 @@ class XSpectrum1D(Spectrum1D):
 
         Parameters
         ----------
-        ituple -- (wave,flux), (wave,flux,sig)
-        If wave is unitless, Angstroms are assumed
+        ituple : (wave,flux), (wave,flux,sig) or (wave,flux,sig,cont)
+          If wave is unitless, Angstroms are assumed
         '''
         # Units
         try:
@@ -84,9 +84,14 @@ class XSpectrum1D(Spectrum1D):
         # Generate
         if len(ituple) == 2: # wave, flux
             spec = cls.from_array(uwave, u.Quantity(ituple[1]))
+        elif len(ituple) == 3:
+            spec = cls.from_array(uwave, u.Quantity(ituple[1]),
+                uncertainty=StdDevUncertainty(ituple[2]))
         else:
             spec = cls.from_array(uwave, u.Quantity(ituple[1]),
                 uncertainty=StdDevUncertainty(ituple[2]))
+            spec.co = ituple[3]
+
         spec.filename = 'none'
         # Return
         return spec


### PR DESCRIPTION
Add the XSpectrum1D copy method, which I accidentally removed in the last PR. Also fixes a bug in the original version.