### PR TITLE
Add a quick plot script (an "xspec lite")

### DIFF
--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -29,3 +29,24 @@ Try::
 	lt_absline -h
 
 for the full set of options.
+
+
+lt_plot
+-------
+
+Plot one or more spectra.
+
+For example::
+
+	lt_plot filename1 filename2
+
+A plot of the spectrum in ``filename1`` appears, and you can navigate
+around it using the same commands as in
+`~linetools.spectra.xspectrum1d.XSpectrum1D.plot`. Move to the next or previous
+spectrum with the right or left arrow key.
+
+To list all the command line options available, use::
+
+        lt_plot -h
+
+

--- a/linetools/analysis/interactive_plot.py
+++ b/linetools/analysis/interactive_plot.py
@@ -177,6 +177,7 @@ class PlotWrapNav(PlotWrapBase):
             fl = fl.value
         self.fl = fl
         self.nsmooth = 0
+        self.last_keypress = None
         # disable existing keypress events (like 's' for save).
         cids = list(fig.canvas.callbacks.callbacks['key_press_event'])
         for cid in cids:
@@ -188,6 +189,9 @@ class PlotWrapNav(PlotWrapBase):
 
     def on_keypress(self, event):
         """ Print a help message"""
+
+        # store the last key pressed
+        self.last_keypress = event.key
         if event.key == '?':
             print(self._help_string)
 

--- a/linetools/scripts/linet_absline.py
+++ b/linetools/scripts/linet_absline.py
@@ -7,13 +7,12 @@ Also print the line data
   linet_absline 1334.3    13.5 7
   linet_absline 1215.6701 14.0 30
 """
-
 import pdb
-
 
 def plot_absline(wrest,logN,b):
     """Plot an absorption line with N,b properties
-    Parmaeters
+
+    Parameters
     ----------
     wrest : float
       Rest wavelength (Ang)
@@ -55,9 +54,10 @@ def plot_absline(wrest,logN,b):
     xspec.plot()
 
 def main(args=None):
-    from astropy.utils.compat import argparse
+    import argparse
     # Parse
-    parser = argparse.ArgumentParser(description='Parser for linet_absline')
+    parser = argparse.ArgumentParser(
+        description='Plot an absorption line with the given parameters.')
     parser.add_argument("wrest", type=float, help="Rest wavelength in Angstroms")
     parser.add_argument("logN", type=float, help="log10 column density")
     parser.add_argument("b", type=float, help="b-value in km/s")

--- a/linetools/scripts/lt_plot.py
+++ b/linetools/scripts/lt_plot.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+""" Plot a spectrum
+"""
+from __future__ import (print_function, absolute_import, division,
+                        unicode_literals)
+
+def plotspec(args):
+    """Plot spectrum files
+
+    Parameters
+    ----------
+    filenames : list of str
+      Spectrum filenames
+    """
+    from linetools.spectra.io import readspec
+    import warnings
+    import matplotlib.pyplot as plt
+    import matplotlib as mpl
+    warnings.simplefilter('ignore', mpl.mplDeprecation)
+    
+    spec_cache = {}
+
+    fig = plt.figure(figsize=(10,5))
+    fig.subplots_adjust(left=0.07, right=0.95, bottom=0.11)
+    ax = fig.add_subplot(111)
+    i = 0
+    quit = False
+    print("#### Use left and right arrow keys to navigate, 'Q' to quit ####")
+
+    while quit is False:
+        filename = args.filenames[i]
+        if filename not in spec_cache:
+            spec_cache[filename] = readspec(filename)
+        sp = spec_cache[filename]
+        ax.cla()
+        sp.plot(show=False)
+        ax.set_xlabel(str(sp.wavelength.unit))
+        ax.set_title(filename)
+        if args.redshift is not None:
+            from linetools.lists.linelist import LineList
+            ll = LineList('Strong')
+            #import pdb ;pdb.set_trace()
+            wlines = ll._data['wrest'] * (1 + args.redshift)
+            y0, y1 = ax.get_ylim()
+            ax.vlines(wlines.to(sp.wavelength.unit).value, y0, y1,
+                      linestyle='dotted')
+
+        while True:
+            plt.waitforbuttonpress()
+            if sp._plotter.last_keypress == 'right':
+                i += 1
+                i = min(i, len(args.filenames) - 1)
+                # Note this only breaks out of the inner while loop
+                break
+            elif sp._plotter.last_keypress == 'left':
+                i -= 1
+                i = max(i, 0)
+                break
+            elif sp._plotter.last_keypress == 'Q':
+                quit = True
+                break
+
+
+def main(args=None):
+    import argparse
+    # Parse
+    parser = argparse.ArgumentParser(description='Plot spectrum files')
+    parser.add_argument("filenames", nargs='+',
+                        help="Spectrum filenames")
+    parser.add_argument("-z", "--redshift", type=float, default=None,
+                        help="Redshift for line plotting")
+
+    args = parser.parse_args()
+    plotspec(args)

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ package_info['package_data'][PACKAGENAME] += data_files
 entry_points = {}
 entry_points['console_scripts'] = [
     'lt_absline = linetools.scripts.linet_absline:main',
+    'lt_plot = linetools.scripts.lt_plot:main',
 #    'astropy-package-template-example = packagename.example_mod:main',
 ]
 


### PR DESCRIPTION
This adds a simple command-line script to plot one or more spectrum files. Currently it's not much more than a wrapper around `XSpectrum1D.plot`.