### PR TITLE
Remove convolve_window, doc changes, normalise gaussian smoothing kernel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 
-
 # The apt packages below are needed for sphinx builds, which can no longer
 # be installed with sudo apt-get.
 addons:
@@ -38,25 +37,18 @@ matrix:
 
         # Check for sphinx doc build warnings - we do this first because it
         # may run for a long time. Add -w flag to fail on any warning.
-        #- python: 2.7
-        #  env: SETUP_CMD='build_sphinx'
         #- python: 3.4
         #  env: SETUP_CMD='build_sphinx -w'
-
 
         # Try Astropy development version
         #- python: 2.7
         #  env: ASTROPY_VERSION=development SETUP_CMD='test'
-        #- python: 3.3
+        #- python: 3.5
         #  env: ASTROPY_VERSION=development SETUP_CMD='test'
 
         # Try all python versions with the latest numpy
-        #- python: 2.6
-        #  env: SETUP_CMD='test'
         - python: 2.7
           env: SETUP_CMD='test'
-        #- python: 3.3
-        #  env: SETUP_CMD='test'
         - python: 3.4
           env: SETUP_CMD='test'
         - python: 3.5
@@ -65,13 +57,6 @@ matrix:
         # Try older numpy versions.
         - python: 2.7
           env: NUMPY_VERSION=1.9 SETUP_CMD='test'
-        # Skip these, because the require astropy versions < 1.0
-        #- python: 2.7
-        #  env: NUMPY_VERSION=1.8 SETUP_CMD='test'
-        #- python: 2.7
-        #  env: NUMPY_VERSION=1.7 SETUP_CMD='test'
-        #- python: 2.7
-        #  env: NUMPY_VERSION=1.6 SETUP_CMD='test'
 
 before_install:
 
@@ -87,10 +72,10 @@ before_install:
     - conda update --yes conda
 
     # UPDATE APT-GET LISTINGS
-    - sudo apt-get update
+    #- sudo apt-get update
 
     # DOCUMENTATION DEPENDENCIES
-    - if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install graphviz texlive-latex-extra dvipng; fi
+    # - if [[ $SETUP_CMD == build_sphinx* ]]; then sudo apt-get install graphviz texlive-latex-extra dvipng; fi
 
 install:
 

--- a/docs/abscomp.rst
+++ b/docs/abscomp.rst
@@ -1,5 +1,3 @@
-.. highlight:: rest
-
 .. _AbsComponent:
 
 ******************

--- a/docs/absline.rst
+++ b/docs/absline.rst
@@ -1,5 +1,3 @@
-.. highlight:: rest
-
 .. _AbsLine:
 
 *************

--- a/docs/abssys.rst
+++ b/docs/abssys.rst
@@ -1,5 +1,3 @@
-.. highlight:: rest
-
 .. _AbsSystem:
 
 ******************

--- a/docs/builddocs.sh
+++ b/docs/builddocs.sh
@@ -1,5 +1,7 @@
 rm -rf ../build/lib.macosx-10.5-x86_64-3.4/
 rm -rf _build/html
+rm -rf _api/*
 cd ..
 python setup.py build_sphinx -w
+#python setup.py build_sphinx
 cd docs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,15 +80,6 @@ copyright = '{0}, {1}'.format(
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
 # built documents.
-extensions = [
-    'sphinx.ext.autodoc',
-    # uncomment below to allow links to external docs
-    #'sphinx.ext.intersphinx',
-    'sphinx.ext.mathjax',
-    'astropy_helpers.sphinx.ext.numpydoc',
-    'astropy_helpers.sphinx.ext.automodapi',
-    'astropy_helpers.sphinx.ext.viewcode',
-]
 
 __import__(setup_cfg['package_name'])
 package = sys.modules[setup_cfg['package_name']]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,13 +31,12 @@ Contents
    AbsComponent <abscomp>
    AbsSystem <abssys>
    SolarAbund <solar>
+   XSpectrum1D <xspectrum1d>
 
 ..
    To be added:
 
    linelist
-   spectralline
-   xspectrum1d
 
 **Methods and Scripts**
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,5 +1,3 @@
-.. highlight:: rest
-
 ************
 Installation
 ************

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -1,5 +1,3 @@
-.. highlight:: rest
-
 ****************
 linetool Scripts
 ****************

--- a/docs/solar.rst
+++ b/docs/solar.rst
@@ -1,5 +1,3 @@
-.. highlight:: rest
-
 .. _SolarAbund:
 
 ******************

--- a/docs/xspectrum1d.rst
+++ b/docs/xspectrum1d.rst
@@ -1,0 +1,19 @@
+.. _XSpectrum1D:
+
+*****************
+XSpectrum1D Class
+*****************
+
+.. index:: XSpectrum1D
+
+Notebooks
+=========
+
+
+Overview
+========
+
+This Class describes a spectrum. It subclasses the specutils
+Spectrum1D class, adding several new attributes and methods.
+
+

--- a/linetools/spectra/convolve.py
+++ b/linetools/spectra/convolve.py
@@ -8,7 +8,8 @@ import numpy as np
 from astropy.convolution import convolve, Gaussian1DKernel, CustomKernel
 
 #Updated functions using astropy.convolution
-def convolve_psf(array, fwhm, boundary='fill', fill_value=0., normalize_kernel=False):
+def convolve_psf(array, fwhm, boundary='fill', fill_value=0.,
+                 normalize_kernel=True):
     """ Convolve an array with a gaussian kernel.
 
     Given an array of values `a` and a gaussian full width at half
@@ -55,49 +56,7 @@ def convolve_psf(array, fwhm, boundary='fill', fill_value=0., normalize_kernel=F
     # centre of gaussian is:
     n = np.ceil(const100 * sigma)
     x_size = int(2*n) + 1 # we want this to be odd integer
-    return convolve(array, Gaussian1DKernel(sigma,x_size=x_size),boundary=boundary,fill_value=fill_value,normalize_kernel=normalize_kernel)
+    return convolve(array, Gaussian1DKernel(sigma, x_size=x_size),
+                    boundary=boundary, fill_value=fill_value,
+                    normalize_kernel=normalize_kernel)
 
-def convolve_window(array, window, boundary='fill', fill_value=0., normalize_kernel=True):
-    """ Convolve an array with an arbitrary window kernel.
-
-    Parameters
-    ----------
-    array : array, shape (N,)
-        Array to convolve
-    window : array, shape (M,)
-        The window array must have an odd number of elements.
-    boundary : str, optional
-        A flag indicating how to handle boundaries:
-            * `None`
-                Set the ``result`` values to zero where the kernel
-                extends beyond the edge of the array (default).
-            * 'fill'
-                Set values outside the array boundary to ``fill_value``.
-            * 'wrap'
-                Periodic boundary that wrap to the other side of ``array``.
-            * 'extend'
-                Set values outside the array to the nearest ``array``
-                value.
-    fill_value : float, optional
-        The value to use outside the array when using boundary='fill'
-    normalize_kernel : bool, optional
-        Whether to normalize the kernel prior to convolving
-
-    Returns
-    -------
-    convolved_array : array, shape (N,)
-    
-    Notes
-    -----
-    This function uses astropy.convolution, and astropy.modeling
-
-    If `window` kernel is as large or larger than `array`, it raises an error.
-
-    """
-    if not len(window) % 2:
-        raise ValueError('`window` must have an odd number of elements!')
-
-    if len(window) >= len(array):
-        raise ValueError('`window` is too big for the `array`!')
-
-    return convolve(array, CustomKernel(window),boundary=boundary,fill_value=fill_value,normalize_kernel=normalize_kernel)

--- a/linetools/spectra/tests/test_xspectrum_utils.py
+++ b/linetools/spectra/tests/test_xspectrum_utils.py
@@ -47,7 +47,7 @@ def test_gauss_smooth(spec):
     # Smooth
     smth_spec = spec.gauss_smooth(4.)
     # Test
-    np.testing.assert_allclose(smth_spec.flux[3000].value, 0.8288110494613)
+    np.testing.assert_allclose(smth_spec.flux[3000].value, 0.82889723777)
     assert smth_spec.flux.unit == spec.flux.unit
 
 # Rebin


### PR DESCRIPTION
This has a few changes (sorry):

 * Remove the convolve_window function, which I don't think is used anywhere
 * Remove the rest highlighting commands at the top of the doc files, because they prevent code highlighting in examples
 * Normalise the Gaussian smoothing kernel in convolve_psf. Without this,  a spectrum's normalisation changes a lot when you smooth it with a narrow psfs.