### PR TITLE
Fix bug in continuum fitting

### DIFF
--- a/linetools/analysis/interactive_plot.py
+++ b/linetools/analysis/interactive_plot.py
@@ -262,8 +262,12 @@ q        : quit
             c = raw_input('knots file exists, use this? (y) ')
             if c.lower() != 'n':
                 contpoints = loadjson('./_knots.jsn')
-        contpoints = sorted(tuple(cp) for cp in contpoints)
+        # need the float call here to make sure values are all float64
+        # and thus json serializable.
+        contpoints = sorted(tuple(float(val) for val in cp) for
+                            cp in contpoints)
 
+        #import pdb; pdb.set_trace()
         if co is not None:
             self.continuum = np.array(co, copy=True)
             if self.anchor is None:
@@ -301,8 +305,8 @@ q        : quit
         contpoints[-1] = wa[i2], y
         self.indices = i1, i2
         if self.anchor:
-            self.anchor_start = wa[i1 - 1], co[i1 - 1]
-            self.anchor_end = wa[i2 + 1], co[i2 + 1]
+            self.anchor_start = wa[i1 - 1], float(co[i1 - 1])
+            self.anchor_end = wa[i2 + 1], float(co[i2 + 1])
         self.contpoints = contpoints
         self.wmin = wmin
         self.wmax = wmax
@@ -445,8 +449,8 @@ q        : quit
             xnew = []
             xnew.extend(np.array(xc[:-1]) + 0.5*np.diff(xc))
             ynew = np.interp(xnew, xc, yc)
-            ynew = [local_median(self.wa, self.fl, self.er, xnew[i],
-                                 default=ynew[i])
+            ynew = [float(local_median(self.wa, self.fl, self.er, xnew[i],
+                                       default=ynew[i]))
                     for i in range(len(xnew))]
             # add to contpoints
             self.contpoints.extend(zip(xnew, ynew))
@@ -470,7 +474,7 @@ q        : quit
             # add a point to contpoints
             x, y = event.xdata, event.ydata
             if not self.contpoints or x not in list(zip(*self.contpoints))[0]:
-                self.contpoints.append((x, y))
+                self.contpoints.append((x, float(y)))
                 self.contpoints.sort()
                 self.update()
         if event.key == 'A':
@@ -482,7 +486,7 @@ q        : quit
             if not self.contpoints or x not in list(zip(*self.contpoints))[0]:
                 y = local_median(self.wa, self.fl, self.er, x,
                                  default=event.ydata)
-                self.contpoints.append((x, y))
+                self.contpoints.append((x, float(y)))
                 self.contpoints.sort()
                 self.update()
         elif event.key in ('d', '4'):
@@ -530,7 +534,7 @@ q        : quit
                     x not in list(zip(*self.contpoints))[0]):
                 y = local_median(self.wa, self.fl, self.er, x,
                                  default=event.ydata)
-            self.contpoints[ind] = x, y
+            self.contpoints[ind] = x, float(y)
             self.contpoints.sort()
             self.update()
 

--- a/linetools/spectra/xspectrum1d.py
+++ b/linetools/spectra/xspectrum1d.py
@@ -755,6 +755,9 @@ or QtAgg backends to enable all interactive plotting commands.
         else:
             knots = [list(k) for k in knots]
 
+        if not len(knots) > 0:
+            raise RuntimeError('Problem generating continuum spline knots')
+
         co = (self.co if hasattr(self, 'co') else None)
         if co is not None:
             x = [k[0] for k in knots]

--- a/linetools/utils.py
+++ b/linetools/utils.py
@@ -85,25 +85,18 @@ def savejson(filename, obj, overwrite=False, indent=None):
     if os.path.lexists(filename) and not overwrite:
         raise IOError('%s exists' % filename)
     if filename.endswith('.gz'):
-        fh = gzip.open(filename, 'wt')
+        with gzip.open(filename, 'wt') as fh:
+            json.dump(obj, fh, indent=indent)
     else:
-        fh = open(filename, 'wt')
-    try:
-        json.dump(obj, fh, indent=indent)
-    except:
-        import pdb; pdb.set_trace()
+        with open(filename, 'wt') as fh:
+            json.dump(obj, fh, indent=indent)
 
-    fh.close()
 
 def loadjson(filename):
     """ Load a python object saved with savejson."""
-    fh = open(filename, 'rt')
-    try:
+    with open(filename, 'rt') as fh:
         obj = json.load(fh)
-    except:
-        import pdb; pdb.set_trace()
-        
-    fh.close()
+
     return obj
 
 


### PR DESCRIPTION
This fixes a bug in the continuum fitting code: it would fail to save continuum points if the spectrum's flux is type numpy.float32, instead of the numpy float64 (which is the native python type, I think).

It also adds a (slightly) more informative error message if no continuum spline points are found, and cleans up the loadjson and savejson functions.