### PR TITLE
Add a link to the original examples notebooks in the sphinx rst versions

### DIFF
--- a/docs/AbsComponent_ColumnDensities.rst
+++ b/docs/AbsComponent_ColumnDensities.rst
@@ -2,6 +2,8 @@
 Column Densities with AbsComponent
 ==================================
 
+Download :download:`examples/AbsComponent_ColumnDensities.ipynb` this notebook.
+
 .. code:: python
 
     %matplotlib inline

--- a/docs/AbsComponent_examples.rst
+++ b/docs/AbsComponent_examples.rst
@@ -2,6 +2,8 @@
 Examples for the AbsComponent Class (v0.3)
 ==========================================
 
+Download :download:`examples/AbsComponent_examples.ipynb` this notebook.
+
 .. code:: python
 
     %matplotlib inline

--- a/docs/AbsLine_examples.rst
+++ b/docs/AbsLine_examples.rst
@@ -1,11 +1,15 @@
 
-Examples for AbsLine class (v1.1)
+Examples for AbsLine class (v1.2)
 =================================
+
+Download :download:`examples/AbsLine_examples.ipynb` this notebook.
 
 .. code:: python
 
     # import
-    from linetools.spectralline import AbsLine
+    from linetools.spectralline import AbsLine, SpectralLine
+    from linetools import spectralline as ltsp
+    
     from linetools.spectra import io as lsio
 
 Generate a line
@@ -19,8 +23,8 @@ Generate a line
 
 .. parsed-literal::
 
-    WARNING: UnitsWarning: The unit 'Angstrom' has been deprecated in the FITS standard. Suggested: nm (with data multiplied by 0.1). [astropy.units.format.utils]
-    WARNING:astropy:UnitsWarning: The unit 'Angstrom' has been deprecated in the FITS standard. Suggested: nm (with data multiplied by 0.1).
+    WARNING: UnitsWarning: The unit 'Angstrom' has been deprecated in the FITS standard. Suggested: 10**-1 nm. [astropy.units.format.utils]
+    WARNING:astropy:UnitsWarning: The unit 'Angstrom' has been deprecated in the FITS standard. Suggested: 10**-1 nm.
 
 
 .. parsed-literal::
@@ -30,14 +34,30 @@ Generate a line
     linetools.lists.parse: Reading linelist --- 
        /Users/xavier/local/Python/linetools/linetools/data/lines/morton00_table2.fits.gz
     linetools.lists.parse: Reading linelist --- 
+       /Users/xavier/local/Python/linetools/linetools/data/lines/verner96_tab1.fits.gz
+    linetools.lists.parse: Reading linelist --- 
        /Users/xavier/local/Python/linetools/linetools/data/lines/verner94_tab6.fits
+
+.. parsed-literal::
+
+    WARNING: UnitsWarning: '0.1nm' did not parse as fits unit: Numeric factor not supported by FITS [astropy.units.core]
+    WARNING:astropy:UnitsWarning: '0.1nm' did not parse as fits unit: Numeric factor not supported by FITS
+
+
+.. parsed-literal::
+
+    
+    linetools.lists.parse: Reading linelist --- 
+       /Users/xavier/local/Python/linetools/linetools/data/lines/EUV_lines.ascii
+    read_sets: Using set file -- 
+      /Users/xavier/local/Python/linetools/linetools/lists/sets/llist_v1.0.ascii
 
 
 
 
 .. parsed-literal::
 
-    [AbsLine: CIV 1548, wrest=1548.1950 Angstrom]
+    <AbsLine: CIV 1548, wrest=1548.1950 Angstrom>
 
 
 
@@ -62,6 +82,8 @@ Data
      'Jk': 0.0,
      'Ref': 'Verner1994',
      'Z': 6,
+     'col0': masked,
+     'col7': masked,
      'el': 0,
      'f': 0.18999999761581421,
      'gamma': <Quantity 0.0 1 / s>,
@@ -77,6 +99,85 @@ Data
 
 
 
+As dict
+~~~~~~~
+
+.. code:: python
+
+    abslin = AbsLine(1548.195*u.AA)
+    tmp = abslin.to_dict()
+    tmp
+
+
+
+
+.. parsed-literal::
+
+    {'analy': {u'datafile': u'',
+      u'do_analysis': 1,
+      u'flg_eye': 0,
+      u'flg_limit': 0,
+      u'name': 'CIV 1548',
+      u'vlim': {'unit': u'km / s', 'value': [0.0, 0.0]},
+      u'wvlim': {'unit': u'Angstrom', 'value': [0.0, 0.0]}},
+     'attrib': {u'DEC': 0.0,
+      u'EW': {'unit': u'Angstrom', 'value': 0.0},
+      u'N': {'unit': u'1 / cm2', 'value': 0.0},
+      u'RA': 0.0,
+      u'b': {'unit': u'km / s', 'value': 0.0},
+      u'flag_EW': 0,
+      u'flag_N': 0,
+      u'sig_EW': {'unit': u'Angstrom', 'value': 0.0},
+      u'sig_N': {'unit': u'1 / cm2', 'value': 0.0},
+      u'sig_b': {'unit': u'km / s', 'value': 0.0},
+      u'sig_v': {'unit': u'km / s', 'value': 0.0},
+      u'sig_z': 0.0,
+      u'v': {'unit': u'km / s', 'value': 0.0},
+      u'z': 0.0},
+     'data': {'A': {'unit': u'1 / s', 'value': 0.0},
+      'Am': 0,
+      'Ej': {'unit': u'1 / cm', 'value': 0.0},
+      'Ek': {'unit': u'1 / cm', 'value': 0.0},
+      'Ex': {'unit': u'1 / cm', 'value': 0.0},
+      'Jj': 0.0,
+      'Jk': 0.0,
+      'Ref': 'Verner1994',
+      'Z': 6,
+      'el': 0,
+      'f': 0.18999999761581421,
+      'gamma': {'unit': u'1 / s', 'value': 0.0},
+      'gj': 2,
+      'gk': 4,
+      'group': 1,
+      'ion': 4,
+      'mol': '',
+      'name': 'CIV 1548',
+      'nj': 0,
+      'nk': 0,
+      'wrest': {'unit': u'Angstrom', 'value': 1548.195}},
+     'ltype': u'Abs',
+     'trans': 'CIV 1548',
+     'wrest': {'unit': u'Angstrom', 'value': 1548.195}}
+
+
+
+From dict
+~~~~~~~~~
+
+.. code:: python
+
+    tmp2 = SpectralLine.from_dict(tmp)
+    tmp2
+
+
+
+
+.. parsed-literal::
+
+    <AbsLine: CIV 1548, wrest=1548.1950 Angstrom>
+
+
+
 Measure an EW
 -------------
 
@@ -84,13 +185,6 @@ Measure an EW
 
     # Set spectrum
     abslin.analy['spec'] = lsio.readspec('../../linetools/spectra/tests/files/UM184_nF.fits')
-
-
-.. parsed-literal::
-
-    /Users/xavier/local/Python/linetools/linetools/spectra/io.py:273: UserWarning: WARNING: CDELT1 < 1e-4, Assuming log wavelength scale
-      warnings.warn('WARNING: CDELT1 < 1e-4, Assuming log wavelength scale')
-
 
 .. code:: python
 
@@ -101,12 +195,12 @@ Measure an EW
 
     # Measure
     abslin.measure_ew() # Observer frame
-    print('EW = {:g} with error {:g}'.format(abslin.attrib['EW'],abslin.attrib['sigEW']))
+    print('EW = {:g} with error {:g}'.format(abslin.attrib['EW'],abslin.attrib['sig_EW']))
 
 
 .. parsed-literal::
 
-    EW = 0.990466 Angstrom with error 0.053301 Angstrom
+    EW = 0.993502 Angstrom with error 0.0527114 Angstrom
 
 
 Measure AODM
@@ -123,11 +217,12 @@ Measure AODM
 .. code:: python
 
     abslin.measure_aodm()
-    N, sigN, flgN = [abslin.attrib[key] for key in ['N','sigN','flagN']] 
+    N, sigN, flgN = [abslin.attrib[key] for key in ['N','sig_N','flag_N']] 
     print('logN = {:g}, siglogN = {:g}'.format(abslin.attrib['logN'], abslin.attrib['sig_logN']))
 
 
 .. parsed-literal::
 
-    logN = 13.9037, siglogN = 0.0211602
+    logN = 13.9051, siglogN = 0.0207027
+
 

--- a/docs/AbsSystem_examples.rst
+++ b/docs/AbsSystem_examples.rst
@@ -1,12 +1,19 @@
 
-Examples for AbsSystem Class (v1.0)
+Examples for AbsSystem Class (v1.1)
 ===================================
+
+Download :download:`examples/AbsSystem_examples.ipynb` this notebook.
 
 .. code:: python
 
+    # suppress warnings for these examples
+    import warnings
+    warnings.filterwarnings('ignore')
+    
     # imports
     import imp
     from astropy.coordinates import SkyCoord
+    import astropy.units as u
     
     from linetools.isgm import abssystem as lt_absys
     from linetools.spectralline import AbsLine
@@ -20,7 +27,7 @@ Standard init
 
 .. code:: python
 
-    reload(lt_absys)
+    imp.reload(lt_absys)
     radec = SkyCoord(ra=123.1143*u.deg, dec=-12.4321*u.deg)
     gensys = lt_absys.GenericAbsSystem(radec, 1.244, [-500,500]*u.km/u.s, NHI=16.)
     gensys
@@ -30,7 +37,7 @@ Standard init
 
 .. parsed-literal::
 
-    [GenericAbsSystem: name=Foo type=Generic, 08:12:27.432 -12:25:55.56, z=1.244, NHI=16]
+    <GenericAbsSystem: name=Foo type=Generic, 08:12:27.432 -12:25:55.56, z=1.244, NHI=16>
 
 
 
@@ -55,38 +62,24 @@ One component
 
 .. parsed-literal::
 
-    WARNING: UnitsWarning: The unit 'Angstrom' has been deprecated in the FITS standard. Suggested: 10**-1 nm. [astropy.units.format.utils]
-    WARNING:astropy:UnitsWarning: The unit 'Angstrom' has been deprecated in the FITS standard. Suggested: 10**-1 nm.
-
-
-.. parsed-literal::
-
     linetools.lists.parse: Reading linelist --- 
-       /Users/xavier/local/Python/linetools/linetools/data/lines/morton03_table2.fits.gz
+       /Users/ncrighton/Code/Repo/linetools/build/lib.macosx-10.5-x86_64-3.4/linetools/data/lines/morton03_table2.fits.gz
     linetools.lists.parse: Reading linelist --- 
-       /Users/xavier/local/Python/linetools/linetools/data/lines/morton00_table2.fits.gz
+       /Users/ncrighton/Code/Repo/linetools/build/lib.macosx-10.5-x86_64-3.4/linetools/data/lines/morton00_table2.fits.gz
     linetools.lists.parse: Reading linelist --- 
-       /Users/xavier/local/Python/linetools/linetools/data/lines/verner94_tab6.fits
-
-.. parsed-literal::
-
-    WARNING: UnitsWarning: '0.1nm' did not parse as fits unit: Numeric factor not supported by FITS [astropy.units.core]
-    WARNING:astropy:UnitsWarning: '0.1nm' did not parse as fits unit: Numeric factor not supported by FITS
-
-
-.. parsed-literal::
-
-    
+       /Users/ncrighton/Code/Repo/linetools/build/lib.macosx-10.5-x86_64-3.4/linetools/data/lines/verner96_tab1.fits.gz
     linetools.lists.parse: Reading linelist --- 
-       /Users/xavier/local/Python/linetools/linetools/data/lines/EUV_lines.ascii
+       /Users/ncrighton/Code/Repo/linetools/build/lib.macosx-10.5-x86_64-3.4/linetools/data/lines/verner94_tab6.fits
+    linetools.lists.parse: Reading linelist --- 
+       /Users/ncrighton/Code/Repo/linetools/build/lib.macosx-10.5-x86_64-3.4/linetools/data/lines/EUV_lines.ascii
     read_sets: Using set file -- 
-      /Users/xavier/local/Python/linetools/linetools/lists/sets/llist_v0.3.ascii
+      /Users/ncrighton/Code/Repo/linetools/build/lib.macosx-10.5-x86_64-3.4/linetools/lists/sets/llist_v1.0.ascii
 
 
 .. code:: python
 
     # HILyman system
-    reload(lt_absys)
+    imp.reload(lt_absys)
     HIsys = lt_absys.LymanAbsSystem.from_components([abscomp])
     print(HIsys)
     print(HIsys._components)
@@ -94,12 +87,12 @@ One component
 
 .. parsed-literal::
 
-    [LymanAbsSystem: name= type=HILyman, 08:12:27.432 -12:25:55.56, z=2.92939, NHI=0]
-    [[AbsComponent: 08:12:27.432 -12:25:55.56, Zion=(1,1), z=2.92939, vlim=-300 km / s,300 km / s]]
+    <LymanAbsSystem: name=J081227.432-122555.56_z2.929 type=HILyman, 08:12:27.432 -12:25:55.56, z=2.92939, NHI=0>
+    [<AbsComponent: 08:12:27.432 -12:25:55.56, Name=HI_z2.92939, Zion=(1,1), Ej=0 1 / cm, z=2.92939, vlim=-300 km / s,300 km / s>]
 
 
-Multiple
-^^^^^^^^
+Multiple components
+^^^^^^^^^^^^^^^^^^^
 
 .. code:: python
 
@@ -117,8 +110,8 @@ Multiple
 
 .. code:: python
 
-    # LLS (coming)
-    reload(lt_absys)
+    # Generic 
+    imp.reload(lt_absys)
     LLSsys = lt_absys.GenericAbsSystem.from_components([abscomp,SiII_comp])
     print(LLSsys)
     print(LLSsys._components)
@@ -126,42 +119,76 @@ Multiple
 
 .. parsed-literal::
 
-    [GenericAbsSystem: name=Foo type=Generic, 08:12:27.432 -12:25:55.56, z=2.92939, NHI=0]
-    [[AbsComponent: 08:12:27.432 -12:25:55.56, Zion=(1,1), z=2.92939, vlim=-300 km / s,300 km / s], [AbsComponent: 08:12:27.432 -12:25:55.56, Zion=(14,2), z=2.92939, vlim=-250 km / s,80 km / s]]
+    <GenericAbsSystem: name=Foo type=Generic, 08:12:27.432 -12:25:55.56, z=2.92939, NHI=0>
+    [<AbsComponent: 08:12:27.432 -12:25:55.56, Name=HI_z2.92939, Zion=(1,1), Ej=0 1 / cm, z=2.92939, vlim=-300 km / s,300 km / s>, <AbsComponent: 08:12:27.432 -12:25:55.56, Name=SiII_z2.92939, Zion=(14,2), Ej=0 1 / cm, z=2.92939, vlim=-250 km / s,80 km / s>]
 
+
+Methods
+-------
+
+List of AbsLines
+~~~~~~~~~~~~~~~~
 
 .. code:: python
 
-    lya.data
+    lines = LLSsys.list_of_abslines()
+    lines
 
 
 
 
 .. parsed-literal::
 
-    {'A': <Quantity 626500000.0 1 / s>,
-     'Am': 0,
-     'Ej': <Quantity 0.0 1 / cm>,
-     'Ek': <Quantity 2259.163 1 / cm>,
-     'Ex': <Quantity 0.0 1 / cm>,
-     'Jj': 0.0,
-     'Jk': 0.0,
-     'Ref': 'Morton2003',
-     'Z': 1,
-     'col0': masked,
-     'col6': masked,
-     'el': 0,
-     'f': 0.41639999999999999,
-     'gamma': <Quantity 626500000.0 1 / s>,
-     'gj': 2,
-     'gk': 6,
-     'group': 1,
-     'ion': 1,
-     'mol': '',
-     'name': 'HI 1215',
-     'nj': 0,
-     'nk': 0,
-     'wrest': <Quantity 1215.67 Angstrom>}
+    [<AbsLine: HI 1215, wrest=1215.6700 Angstrom>,
+     <AbsLine: HI 1025, wrest=1025.7222 Angstrom>,
+     <AbsLine: SiII 1260, wrest=1260.4221 Angstrom>,
+     <AbsLine: SiII 1304, wrest=1304.3702 Angstrom>,
+     <AbsLine: SiII 1526, wrest=1526.7070 Angstrom>,
+     <AbsLine: SiII 1808, wrest=1808.0129 Angstrom>]
+
+
+
+Single Line
+~~~~~~~~~~~
+
+.. code:: python
+
+    lyb = LLSsys.get_absline('HI 1025')
+    lyb
+
+
+
+
+.. parsed-literal::
+
+    <AbsLine: HI 1025, wrest=1025.7222 Angstrom>
+
+
+
+.. code:: python
+
+    lyb = LLSsys.get_absline(1025.72*u.AA)
+    lyb
+
+
+
+
+.. parsed-literal::
+
+    <AbsLine: HI 1025, wrest=1025.7222 Angstrom>
+
+
+
+.. code:: python
+
+    lyb.wrest
+
+
+
+
+.. math::
+
+    1025.7222 \; \mathrm{\mathring{A}}
 
 
 

--- a/docs/SolarAbund.rst
+++ b/docs/SolarAbund.rst
@@ -2,6 +2,8 @@
 Examples with the SolarAbund Class (v1.1)
 =========================================
 
+Download :download:`examples/SolarAbund.ipynb` this notebook.
+
 .. code:: python
 
     # import

--- a/docs/examples/AbsSystem_examples.ipynb
+++ b/docs/examples/AbsSystem_examples.ipynb
@@ -9,15 +9,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
    "outputs": [],
    "source": [
+    "# suppress warnings for these examples\n",
+    "import warnings\n",
+    "warnings.filterwarnings('ignore')\n",
+    "\n",
     "# imports\n",
     "import imp\n",
     "from astropy.coordinates import SkyCoord\n",
+    "import astropy.units as u\n",
     "\n",
     "from linetools.isgm import abssystem as lt_absys\n",
     "from linetools.spectralline import AbsLine\n",
@@ -40,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
@@ -51,13 +56,13 @@
        "<GenericAbsSystem: name=Foo type=Generic, 08:12:27.432 -12:25:55.56, z=1.244, NHI=16>"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "reload(lt_absys)\n",
+    "imp.reload(lt_absys)\n",
     "radec = SkyCoord(ra=123.1143*u.deg, dec=-12.4321*u.deg)\n",
     "gensys = lt_absys.GenericAbsSystem(radec, 1.244, [-500,500]*u.km/u.s, NHI=16.)\n",
     "gensys"
@@ -79,50 +84,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: UnitsWarning: The unit 'Angstrom' has been deprecated in the FITS standard. Suggested: 10**-1 nm. [astropy.units.format.utils]\n",
-      "WARNING:astropy:UnitsWarning: The unit 'Angstrom' has been deprecated in the FITS standard. Suggested: 10**-1 nm.\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
       "linetools.lists.parse: Reading linelist --- \n",
-      "   /Users/xavier/local/Python/linetools/linetools/data/lines/morton03_table2.fits.gz\n",
+      "   /Users/ncrighton/Code/Repo/linetools/build/lib.macosx-10.5-x86_64-3.4/linetools/data/lines/morton03_table2.fits.gz\n",
       "linetools.lists.parse: Reading linelist --- \n",
-      "   /Users/xavier/local/Python/linetools/linetools/data/lines/morton00_table2.fits.gz\n",
+      "   /Users/ncrighton/Code/Repo/linetools/build/lib.macosx-10.5-x86_64-3.4/linetools/data/lines/morton00_table2.fits.gz\n",
       "linetools.lists.parse: Reading linelist --- \n",
-      "   /Users/xavier/local/Python/linetools/linetools/data/lines/verner96_tab1.fits.gz\n",
+      "   /Users/ncrighton/Code/Repo/linetools/build/lib.macosx-10.5-x86_64-3.4/linetools/data/lines/verner96_tab1.fits.gz\n",
       "linetools.lists.parse: Reading linelist --- \n",
-      "   /Users/xavier/local/Python/linetools/linetools/data/lines/verner94_tab6.fits"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING: UnitsWarning: '0.1nm' did not parse as fits unit: Numeric factor not supported by FITS [astropy.units.core]\n",
-      "WARNING:astropy:UnitsWarning: '0.1nm' did not parse as fits unit: Numeric factor not supported by FITS\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\n",
+      "   /Users/ncrighton/Code/Repo/linetools/build/lib.macosx-10.5-x86_64-3.4/linetools/data/lines/verner94_tab6.fits\n",
       "linetools.lists.parse: Reading linelist --- \n",
-      "   /Users/xavier/local/Python/linetools/linetools/data/lines/EUV_lines.ascii\n",
+      "   /Users/ncrighton/Code/Repo/linetools/build/lib.macosx-10.5-x86_64-3.4/linetools/data/lines/EUV_lines.ascii\n",
       "read_sets: Using set file -- \n",
-      "  /Users/xavier/local/Python/linetools/linetools/lists/sets/llist_v1.0.ascii\n"
+      "  /Users/ncrighton/Code/Repo/linetools/build/lib.macosx-10.5-x86_64-3.4/linetools/lists/sets/llist_v1.0.ascii\n"
      ]
     }
    ],
@@ -140,7 +122,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -156,7 +138,7 @@
    ],
    "source": [
     "# HILyman system\n",
-    "reload(lt_absys)\n",
+    "imp.reload(lt_absys)\n",
     "HIsys = lt_absys.LymanAbsSystem.from_components([abscomp])\n",
     "print(HIsys)\n",
     "print(HIsys._components)"
@@ -171,7 +153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -192,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -208,7 +190,7 @@
    ],
    "source": [
     "# Generic \n",
-    "reload(lt_absys)\n",
+    "imp.reload(lt_absys)\n",
     "LLSsys = lt_absys.GenericAbsSystem.from_components([abscomp,SiII_comp])\n",
     "print(LLSsys)\n",
     "print(LLSsys._components)"
@@ -232,7 +214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 12,
    "metadata": {
     "collapsed": false
    },
@@ -248,7 +230,7 @@
        " <AbsLine: SiII 1808, wrest=1808.0129 Angstrom>]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -267,7 +249,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
@@ -278,7 +260,7 @@
        "<AbsLine: HI 1025, wrest=1025.7222 Angstrom>"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -290,7 +272,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 14,
    "metadata": {
     "collapsed": false
    },
@@ -301,7 +283,7 @@
        "<AbsLine: HI 1025, wrest=1025.7222 Angstrom>"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -313,7 +295,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 15,
    "metadata": {
     "collapsed": false
    },
@@ -327,7 +309,7 @@
        "<Quantity 1025.7222 Angstrom>"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -348,21 +330,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "pygments_lexer": "ipython3",
+   "version": "3.4.4"
   }
  },
  "nbformat": 4,

--- a/docs/nb_to_rst.src
+++ b/docs/nb_to_rst.src
@@ -1,11 +1,25 @@
 #/bin/tcsh
-# Converts notebooks to rst
+
+# Converts notebooks to rst and insert a line at the top with a link
+# to the original notebook.
+
 # Requires pandoc https://github.com/jgm/pandoc/releases/tag/1.15.2
 
-ipython nbconvert examples/AbsComponent_examples.ipynb --to rst
-ipython nbconvert examples/AbsComponent_ColumnDensities.ipynb --to rst
-ipython nbconvert examples/AbsSystem_examples.ipynb --to rst
-ipython nbconvert examples/AbsLine_examples.ipynb --to rst
-ipython nbconvert examples/SolarAbund.ipynb --to rst
-ipython nbconvert examples/xspecgui.ipynb --to rst
+for n in AbsComponent_examples \
+    AbsComponent_ColumnDensities \
+    AbsSystem_examples \
+    AbsLine_examples \
+    SolarAbund \
+    xspecgui
 
+do  
+    	echo examples/$n\.ipynb
+	echo $n\.rst
+	ipython nbconvert examples/$n.ipynb --to rst;
+	sed -i '' "5 i\\
+ Download :download:\`examples/$n\.ipynb\` this notebook.\\
+\\
+
+" $n\.rst;
+
+done

--- a/docs/xspecgui.rst
+++ b/docs/xspecgui.rst
@@ -2,6 +2,8 @@
 xspec Documentation
 ===================
 
+Download :download:`examples/xspecgui.ipynb` this notebook.
+
 This ipython Notebook is intended to provide documentation for the
 linetools GUI named XSpecGUI.
 


### PR DESCRIPTION
This alters the notebook conversion script so that at the beginning of each generated .rst file there's a link to the original notebook file.