### PR TITLE
Refactor readspec

### DIFF
--- a/docs/xspectrum1d.rst
+++ b/docs/xspectrum1d.rst
@@ -114,10 +114,10 @@ the API: `~linetools.spectra.xspectrum1d.XSpectrum1D`.
 File Formats Read
 =================
 
-Below is a table of the types of spectra files that
-can be read by `~linetools.spectra.io.readspec`.  If
-your file cannot be read, contact the authors and
-stand by.
+Below is a table of the types of spectra files that can be read by
+`~linetools.spectra.io.readspec`.  If your file cannot be read, please
+open an issue on the `linetools issue tracker
+<http://github.com/linetools/linetools/issues>`_.
 
 ========================================================== =================
 Description                                                Instruments
@@ -128,4 +128,7 @@ multi-extension 1D FITS files from LowRedux                LRIS,Kast,etc.
 binary FITS tables from many other sources                 COS, SDSS, etc.
 multi-extension binary FITS tables from PYPIT              LRIS,Kast,etc.
 brick files (2D images: flux, ivar; 1D image: wavelength)  DESI
+`UVES_popler`_ output files                                UVES
 ========================================================== =================
+
+.. _UVES_popler: http://astronomy.swin.edu.au/~mmurphy/UVES_popler/

--- a/linetools/guis/spec_widgets.py
+++ b/linetools/guis/spec_widgets.py
@@ -39,7 +39,7 @@ class ExamineSpecWidget(QtGui.QWidget):
         """
         Parameters
         ----------
-        ispec : Spectrum1D or tuple of arrays
+        ispec : Spectrum1D, tuple of arrays or filename
         exten : int, optional
           extension for the spectrum in multi-extension FITS file
         parent : Widget parent, optional
@@ -65,6 +65,11 @@ class ExamineSpecWidget(QtGui.QWidget):
         self.orig_spec = spec  # For smoothing
         self.spec = self.orig_spec
 
+        if spec.co is not None:
+            self.continuum = XSpectrum1D.from_tuple((spec.wavelength,spec.co))
+        else:
+            self.continuum = None
+
         self.vlines = []
         if vlines is not None:
             self.vlines.extend(vlines)
@@ -72,7 +77,6 @@ class ExamineSpecWidget(QtGui.QWidget):
         self.plotzero = plotzero
 
         # Other bits (modified by other widgets)
-        self.continuum = None
         self.model = None
         self.bad_model = None  # Discrepant pixels in model
         self.use_event = 1
@@ -145,7 +149,7 @@ class ExamineSpecWidget(QtGui.QWidget):
             ymin, ymax = ylim
         #QtCore.pyqtRemoveInputHook()
         #xdb.set_trace()
-        #QtCore.pyqtRestoreInputHook()    
+        #QtCore.pyqtRestoreInputHook()
         self.psdict['x_minmax'] = np.array([xmin, xmax])
         self.psdict['y_minmax'] = [ymin, ymax]
         self.psdict['sv_xy_minmax'] = [[xmin, xmax], [ymin, ymax]]
@@ -446,6 +450,7 @@ class ExamineSpecWidget(QtGui.QWidget):
           Draw the screen on the canvas?
         """
         #
+
         if replot is True:
             self.ax.clear()
             self.ax.plot(self.spec.dispersion, self.spec.flux,
@@ -556,4 +561,3 @@ class ExamineSpecWidget(QtGui.QWidget):
                      'E/E: EW (boxcar)',
                      '$/$: stats on spectrum'
                      ]
-

--- a/linetools/guis/xspecgui.py
+++ b/linetools/guis/xspecgui.py
@@ -19,8 +19,9 @@ class XSpecGui(QtGui.QMainWindow):
     def __init__(self, ispec, parent=None, zsys=None, norm=None, exten=None):
         QtGui.QMainWindow.__init__(self, parent)
         """
-        ispec = Spectrum1D or tuple of arrays
-          Input spectrum.  If tuple then (wave,fx) or (wave,fx,sig)
+        ispec = str, Spectrum1D or tuple of arrays
+          Input spectrum or spectrum filename.  If tuple then (wave,
+          fx), (wave, fx, sig) or (wave, fx, sig, co)
         parent : Widget parent, optional
         zsys : float, optional
           intial redshift

--- a/linetools/spectra/io.py
+++ b/linetools/spectra/io.py
@@ -35,23 +35,24 @@ def readspec(specfil, inflg=None, efil=None, verbose=False, multi_ivar=False,
     ----------
     specfil : str or Table
       Input file. If str:
-        * FITS file must include in '.fit'
-        * ASCII must either have a proper Table format
-          or be 3 columns with WAVE,FLUX,ERROR
+        * FITS file are detected by searching for '.fit' in their filename.
+        * ASCII must either have a proper Table format or be 3 (WAVE,
+          FLUX, ERROR) or 4 (WAVE, FLUX, ERROR, CONTINUUM) columns.
     efil : string, optional
-      Explicit filename for Error array.  Code will attempt to find this
-      file on its own.
+      A filename for Error array, if it's in a separate file to the
+      flux. The code will attempt to find this file on its own.
     multi_ivar : bool, optional
-      If True, assume BOSS format of flux, ivar, log10(wave) in
+      If True, assume BOSS format of flux, ivar, log10(wave) in a
       multi-extension FITS.
     format : str, optional
-      Format for ASCII table input ['ascii']
+      Format for ASCII table input. Default 'ascii'.
     exten : int, optional
       FITS extension (mainly for multiple binary FITS tables or bricks)
 
     Returns
     -------
     An XSpectrum1D class
+
     """
     from specutils.io import read_fits as spec_read_fits
     from linetools.spectra.xspectrum1d import XSpectrum1D
@@ -342,6 +343,17 @@ def chk_for_gz(filenm):
 
 def give_wv_units(wave):
     """ Give a wavelength array units of Angstroms, if unitless.
+
+    Parameters
+    ----------
+    wave : array or Quantity
+      Input wavelength array
+
+    Returns
+    -------
+    uwave: Quantity
+      Output wavelengths in Angstroms if input is unitless, or the
+      input array unchanged otherwise.
     """
     if not hasattr(wave, 'unit'):
         uwave = u.Quantity(wave, unit=u.AA)
@@ -355,6 +367,14 @@ def give_wv_units(wave):
 
 def is_UVES_popler(hd):
     """ Check if this header is UVES_popler output.
+
+    Parameters
+    ----------
+    hd : FITS header
+    
+    Returns
+    -------
+    True if a UVES_popler file, False otherwise.
     """
     if 'history' not in hd:
         return False
@@ -365,6 +385,15 @@ def is_UVES_popler(hd):
 
 def parse_UVES_popler(hdulist):
     """ Read a spectrum from a UVES_popler-style fits file.
+
+    Parameters
+    ----------
+    hdulist : FITS HDU list
+    
+    Returns
+    -------
+    xspec1d : XSpectrum1D
+      Parsed spectrum
     """
     from linetools.spectra.xspectrum1d import XSpectrum1D
 
@@ -378,6 +407,17 @@ def parse_UVES_popler(hdulist):
 
 def parse_FITS_binary_table(hdulist, exten=None):
     """ Read a spectrum from a FITS binary table
+
+    Parameters
+    ----------
+    hdulist : FITS HDU list
+    exten : int, optional
+      Extension for the binary table.
+
+    Returns
+    -------
+    xspec1d : XSpectrum1D
+      Parsed spectrum
     """
     # Flux
     flux_tags = ['SPEC', 'FLUX', 'FLAM', 'FX',
@@ -423,6 +463,17 @@ def parse_FITS_binary_table(hdulist, exten=None):
 
 def parse_linetools_spectrum_format(hdulist):
     """ Parse a linetools-format spectrum from an hdulist
+
+    Parameters
+    ----------
+    hdulist : FITS HDU list
+
+    Returns
+    -------
+    xspec1d : XSpectrum1D
+      Parsed spectrum
+
+
     """
     if 'WAVELENGTH' not in hdulist:
         spec1d = spec_read_fits.read_fits_spectrum1d(
@@ -452,6 +503,17 @@ def parse_linetools_spectrum_format(hdulist):
 
 def parse_DESI_brick(hdulist, exten=None):
     """ Read a spectrum from a DESI brick format HDU list
+
+    Parameters
+    ----------
+    hdulist : FITS HDU list
+    exten : int, optional
+      Extension for the date. Default is 0 (the primary HDU).
+
+    Returns
+    -------
+    xspec1d : XSpectrum1D
+      Parsed spectrum
     """
     if exten is None:
         exten = 0
@@ -470,6 +532,21 @@ def parse_DESI_brick(hdulist, exten=None):
 
 def parse_two_file_format(specfil, hdulist, efil=None):
     """ Parse old two file format (one for flux, another for error).
+
+    Parameters
+    ----------
+    specfil : str
+      Flux filename
+    hdulist : FITS HDU list
+    efil : str, optional
+      Error filename. By default this is inferred from the flux
+      filename.
+
+    Returns
+    -------
+    xspec1d : XSpectrum1D
+      Parsed spectrum
+
     """
     head0 = hdulist[0].header
     # Error

--- a/linetools/spectra/io.py
+++ b/linetools/spectra/io.py
@@ -340,6 +340,19 @@ def chk_for_gz(filenm):
         chk=False
         return None, chk
 
+def give_wv_units(wave):
+    """ Give a wavelength array units of Angstroms, if unitless.
+    """
+    if not hasattr(wave, 'unit'):
+        uwave = u.Quantity(wave, unit=u.AA)
+    elif wave.unit is None:
+        uwave = u.Quantity(wave, unit=u.AA)
+    else:
+        uwave = u.Quantity(wave)
+
+    return uwave
+
+
 def is_UVES_popler(hd):
     """ Check if this header is UVES_popler output.
     """
@@ -453,18 +466,6 @@ def parse_DESI_brick(hdulist, exten=None):
     wave = give_wv_units(wave)
     xspec1d = XSpectrum1D.from_tuple((wave, fx, sig, None))
     return xspec1d
-
-def give_wv_units(wave):
-    """ Give a wavelength array units of Angstroms, if unitless.
-    """
-    if not hasattr(wave, 'unit'):
-        uwave = u.Quantity(wave, unit=u.AA)
-    elif wave.unit is None:
-        uwave = u.Quantity(wave, unit=u.AA)
-    else:
-        uwave = u.Quantity(wave)
-
-    return uwave
 
 
 def parse_two_file_format(specfil, hdulist, efil=None):

--- a/linetools/spectra/tests/test_xspec_init.py
+++ b/linetools/spectra/tests/test_xspec_init.py
@@ -37,6 +37,9 @@ def test_from_tuple():
     spec = XSpectrum1D.from_tuple((idl['wave'],idl['flux'],idl['sig'], co))
     np.testing.assert_allclose(spec.dispersion.value, idl['wave'])
 
+    co = None
+    spec = XSpectrum1D.from_tuple((idl['wave'],idl['flux'],idl['sig'], co))
+    np.testing.assert_allclose(spec.dispersion.value, idl['wave'])
 
 # From file
 def test_from_spec1d():


### PR DESCRIPTION
I found spectra.io.readspec very confusing. This refactors it so it's more clear what is going on (to me anyway, and hopefully other people who aren't @profxj...). 

Note that I also removed the ability to specify flux and wavelength tags, because this makes the code simpler, and because the list of tags in the docs was getting out of sync with the list used in the code.  It now just prints the list of tags if one of them can't be found.

It also makes ExamineSpecWidget plot the continuum by default.