### PR TITLE
Xspec changes

### DIFF
--- a/linetools/guis/line_widgets.py
+++ b/linetools/guis/line_widgets.py
@@ -47,7 +47,7 @@ class PlotLinesWidget(QtGui.QWidget):
         self.connect(self.zbox, QtCore.SIGNAL('editingFinished ()'), self.setz)
 
         # Create the line list
-        self.lists = ['None', 'ISM', 'Strong', 'Galaxy', 'H2', 'EUV']
+        self.lists = ['None', 'ISM', 'Strong', 'HI', 'Galaxy', 'H2', 'EUV']
         #'grb.lst', 'dla.lst', 'lls.lst', 'subLLS.lst',
 #                      'lyman.lst', 'Dlyman.lst', 'gal_vac.lst', 'ne8.lst',
 #                      'lowz_ovi.lst', 'casbah.lst', 'H2.lst']

--- a/linetools/guis/spec_widgets.py
+++ b/linetools/guis/spec_widgets.py
@@ -480,7 +480,7 @@ class ExamineSpecWidget(QtGui.QWidget):
 
             # Continuum?
             if self.spec.co_is_set:
-                self.ax.plot(self.wavelength, self.flux, color='purple')
+                self.ax.plot(self.spec.wavelength, self.spec.co, color='purple')
 
             # Model?
             if self.model is not None:
@@ -507,6 +507,7 @@ class ExamineSpecWidget(QtGui.QWidget):
                     self.ax.plot(wrest*np.array([z+1,z+1]), self.psdict['y_minmax'], 'b--')
                     # Label
                     self.ax.text(wrest*(z+1), ylbl, lbl, color='blue', rotation=90., size='small')
+
 
             # Abs Sys?
             if not self.abs_sys is None:
@@ -543,8 +544,10 @@ class ExamineSpecWidget(QtGui.QWidget):
                 self.adict['flg'] = 0
             # Lya line?
             if self.adict['flg'] == 4:
-                self.ax.plot(self.spec.wavelength,
-                    self.lya_line.flux, color='green')
+                model = self.lya_line.flux
+                if self.spec.co_is_set and not self.norm:
+                    model *= self.spec.co
+                self.ax.plot(self.spec.wavelength, model, color='green')
 
         # Reset window limits
         self.ax.set_xlim(self.psdict['x_minmax'])

--- a/linetools/guis/xspecgui.py
+++ b/linetools/guis/xspecgui.py
@@ -112,9 +112,9 @@ class XSpecGui(QtGui.QMainWindow):
 
 
 def main(args, **kwargs):
-    from specutils.spectrum1d import Spectrum1D
+    from linetools.spectra.xspectrum1d import XSpectrum1D
 
-    if not isinstance(args,(Spectrum1D,tuple,basestring)):
+    if not isinstance(args,(XSpectrum1D,tuple,basestring)):
         raise IOError("Bad input")
     # Run
     app = QtGui.QApplication(sys.argv)


### PR DESCRIPTION
This removes a reference to Spectrum1D, and fixes continuum plotting in ExamineSpecWidget.  It also multiplies the flux model by the continuum when using the 'D' and 'R' options to plot DLA/SLLS profiles.