### PR TITLE
Allow assigning values to XSpectrum1D attributes

### DIFF
--- a/linetools/spectra/tests/test_xspectrum_utils.py
+++ b/linetools/spectra/tests/test_xspectrum_utils.py
@@ -102,7 +102,7 @@ def test_splice(spec, spec2):
 def test_write_ascii(spec):
     # Write. Should be replaced with tempfile.TemporaryFile
     spec.write_to_ascii(data_path('tmp.ascii'))
-    # 
+    #
     spec2 = io.readspec(data_path('tmp.ascii'))
     # check a round trip works
     np.testing.assert_allclose(spec.wavelength, spec2.wavelength)
@@ -178,4 +178,14 @@ def test_continuum_utils(spec):
     np.testing.assert_allclose(spec.flux,flux_old)
 
 
-
+def test_assignment(spec):
+    temp = np.arange(1, len(spec.wavelength) + 1)
+    spec.wavelength =  temp * u.m
+    assert spec.wavelength[0] == temp[0] * u.m
+    unit = u.erg / u.s / u.cm**2 / u.AA
+    spec.flux = temp * unit
+    assert spec.flux[0] == temp[0] * unit
+    spec.sig = temp
+    assert spec.sig[0] == temp[0] * unit
+    spec.co = temp
+    assert spec.co[0] == temp[0] * unit

--- a/linetools/spectra/xspectrum1d.py
+++ b/linetools/spectra/xspectrum1d.py
@@ -225,6 +225,12 @@ class XSpectrum1D(object):
         """
         return self.data[self.select]['wave'] * self.units['wave']
 
+    @wavelength.setter
+    def wavelength(self, value):
+        self.data['wave'][self.select] = value
+        if hasattr(value, 'unit'):
+            self.units['wave'] = value.unit
+
     @property
     def flux(self):
         """ Return the flux with units
@@ -233,6 +239,12 @@ class XSpectrum1D(object):
         if self.normed and self.co_is_set:
             flux /= self.data[self.select]['co']
         return flux
+
+    @flux.setter
+    def flux(self, value):
+        self.data['flux'][self.select] = value
+        if hasattr(value, 'unit'):
+            self.units['flux'] = value.unit
 
     @property
     def sig_is_set(self):
@@ -256,6 +268,13 @@ class XSpectrum1D(object):
             sig /= self.data[self.select]['co']
         return sig
 
+    @sig.setter
+    def sig(self, value):
+        """ Assumes units are the same as the flux
+        """
+        self.data['sig'][self.select] = value
+
+
     @property
     def co_is_set(self):
         """ Returns whether a continuum is defined
@@ -273,6 +292,13 @@ class XSpectrum1D(object):
             warnings.warn("This spectrum does not contain an input continuum array")
             return np.nan
         return self.data[self.select]['co'] * self.units['flux']
+
+    @co.setter
+    def co(self, value):
+        """ Assumes units are the same as the flux
+        """
+        self.data['co'][self.select] = value
+
 
     @property
     def wvmin(self):


### PR DESCRIPTION
This allows assigning arrays directly to the wavelength, flux, sig and co attributes. e.g.

```python
wa = np.arange(10)
fl = np.ones_like(wa)
sp = XSpectrum1d.from_tuple((wa, fl))
wave = np.arange(1, len(sp.wavelength) + 1)
sp.wavelength = wave
```

Units are updated for the wavelength or flux (if the assigned array is a Quantity), and ignored for sig and co.

Tests are included.