### PR TITLE
Scripts: avoid scientific notation when possible for axes tick labels.

### DIFF
--- a/linetools/guis/xspecgui.py
+++ b/linetools/guis/xspecgui.py
@@ -39,6 +39,7 @@ class XSpecGui(QtGui.QMainWindow):
 
         # Needed to avoid crash in large spectral files
         rcParams['agg.path.chunksize'] = 20000
+        rcParams['axes.formatter.useoffset'] = False  # avoid scientific notation in axes tick labels
 
         # Build a widget combining several others
         self.main_widget = QtGui.QWidget()

--- a/linetools/scripts/lt_plot.py
+++ b/linetools/scripts/lt_plot.py
@@ -12,7 +12,9 @@ def plotspec(args):
     import matplotlib.pyplot as plt
     import matplotlib as mpl
     warnings.simplefilter('ignore', mpl.mplDeprecation)
-    
+
+    plt.rcParams['axes.formatter.useoffset'] = False  # avoid scientific notation in axes tick labels
+
     spec_cache = {}
 
     fig = plt.figure(figsize=(10,5))

--- a/linetools/spectra/xspectrum1d.py
+++ b/linetools/spectra/xspectrum1d.py
@@ -477,6 +477,7 @@ class XSpectrum1D(object):
         #matplotlib.use('Agg')
         import matplotlib.pyplot as plt
         from ..analysis.interactive_plot import PlotWrapNav
+        plt.rcParams['axes.formatter.useoffset'] = False  # avoid scientific notation in axes tick labels
 
         nocolor = (False if 'color' in kwargs else True)
         xlim = kwargs.pop('xlim', None)


### PR DESCRIPTION
I find scientific notation annoying in the wavelength axis...