### PR TITLE
AbsSystem/DLASystem: from_components

### DIFF
--- a/linetools/isgm/abssystem.py
+++ b/linetools/isgm/abssystem.py
@@ -106,7 +106,16 @@ class AbsSystem(object):
         init_comp = components[0]
         if vlim is None:
             vlim = init_comp.vlim
-        slf = cls(init_comp.coord, init_comp.zcomp, vlim)
+        # System specific inits
+        if cls.__name__ == 'DLASystem':  # From pyigm
+            # NHI
+            HI_comps = [comp for comp in components if comp.Zion == (1,1)]
+            NHI = 0.
+            for HI_comp in HI_comps:  # Takes only the first line in each list
+                NHI += HI_comp._abslines[0].attrib['N'].value
+            slf = cls(init_comp.coord, init_comp.zcomp, vlim, np.log10(NHI))
+        else:
+            slf = cls(init_comp.coord, init_comp.zcomp, vlim)
         if slf.chk_component(init_comp):
             slf._components.append(init_comp)
         else:

--- a/linetools/isgm/abssystem.py
+++ b/linetools/isgm/abssystem.py
@@ -106,16 +106,15 @@ class AbsSystem(object):
         init_comp = components[0]
         if vlim is None:
             vlim = init_comp.vlim
-        # System specific inits
-        if cls.__name__ == 'DLASystem':  # From pyigm
-            # NHI
-            HI_comps = [comp for comp in components if comp.Zion == (1,1)]
-            NHI = 0.
-            for HI_comp in HI_comps:  # Takes only the first line in each list
-                NHI += HI_comp._abslines[0].attrib['N'].value
-            slf = cls(init_comp.coord, init_comp.zcomp, vlim, np.log10(NHI))
-        else:
-            slf = cls(init_comp.coord, init_comp.zcomp, vlim)
+        # Attempt to set NHI
+        HI_comps = [comp for comp in components if comp.Zion == (1,1)]
+        NHI = 0.
+        for HI_comp in HI_comps:  # Takes only the first line in each list
+            NHI += HI_comp._abslines[0].attrib['N'].value
+        if NHI > 0.:
+            NHI = np.log10(NHI)
+        #
+        slf = cls(init_comp.coord, init_comp.zcomp, vlim, NHI=NHI)
         if slf.chk_component(init_comp):
             slf._components.append(init_comp)
         else:

--- a/linetools/isgm/tests/test_init_abssys.py
+++ b/linetools/isgm/tests/test_init_abssys.py
@@ -15,11 +15,6 @@ from linetools.spectralline import AbsLine
 
 import pdb
 
-class DLASystem(AbsSystem):
-    def __init__(self, radec, zabs, vlim, NHI, **kwargs):
-        AbsSystem.__init__(self, 'DLA', radec, zabs, vlim, NHI=NHI, **kwargs)
-        pass
-
 def test_init():
     # Simple properties
     radec = SkyCoord(ra=123.1143*u.deg, dec=-12.4321*u.deg)
@@ -46,6 +41,7 @@ def test_one_component():
     lya = AbsLine(1215.670*u.AA)
     lya.analy['vlim'] = [-300.,300.]*u.km/u.s
     lya.attrib['z'] = 2.92939
+    lya.attrib['N'] = 1e17 /  u.cm**2
     lyb = AbsLine(1025.7222*u.AA)
     lyb.analy['vlim'] = [-300.,300.]*u.km/u.s
     lyb.attrib['z'] = lya.attrib['z']
@@ -66,6 +62,7 @@ def test_multi_components():
     lya = AbsLine(1215.670*u.AA)
     lya.analy['vlim'] = [-300.,300.]*u.km/u.s
     lya.attrib['z'] = 2.92939
+    lya.attrib['N'] = 1e17 /  u.cm**2
     lyb = AbsLine(1025.7222*u.AA)
     lyb.analy['vlim'] = [-300.,300.]*u.km/u.s
     lyb.attrib['z'] = lya.attrib['z']
@@ -85,5 +82,6 @@ def test_multi_components():
     # Instantiate
     LLSsys = GenericAbsSystem.from_components([abscomp,SiII_comp])
     # Test
+    np.testing.assert_allclose(LLSsys.NHI, 17.0)
     assert len(LLSsys._components) == 2
 

--- a/linetools/isgm/tests/test_init_abssys.py
+++ b/linetools/isgm/tests/test_init_abssys.py
@@ -59,26 +59,6 @@ def test_one_component():
     assert HIsys._components[0].Zion[0] == 1
     assert HIsys._components[0].Zion[1] == 1
 
-def test_DLA_from_components():
-    radec = SkyCoord(ra=123.1143*u.deg, dec=-12.4321*u.deg)
-    # HI Lya, Lyb
-    lya = AbsLine(1215.670*u.AA)
-    lya.analy['vlim'] = [-300.,300.]*u.km/u.s
-    lya.attrib['z'] = 2.92939
-    lya.attrib['N'] = 3e20 / u.cm**2
-    lyb = AbsLine(1025.7222*u.AA)
-    lyb.analy['vlim'] = [-300.,300.]*u.km/u.s
-    lyb.attrib['z'] = lya.attrib['z']
-    lyb.attrib['N'] = 3e20 / u.cm**2
-    abscomp = AbsComponent.from_abslines([lya,lyb])
-    abscomp.coord = radec
-    # Instantiate
-    HIsys = DLASystem.from_components([abscomp])
-    # Test
-    np.testing.assert_allclose(HIsys.NHI, 20.477121254719663)
-    assert len(HIsys._components) == 1
-    assert HIsys._components[0].Zion[0] == 1
-    assert HIsys._components[0].Zion[1] == 1
 
 def test_multi_components():
     radec = SkyCoord(ra=123.1143*u.deg, dec=-12.4321*u.deg)


### PR DESCRIPTION
Puts a 'hook' into AbsSystem specific to DLASystem
which comes from pyigm.

Doesn't generate a dependence of pyigm for linetools,
but is not an elegant approach.  Might be a first
step towards pushing AbsSystem into pyigm..