### PR TITLE
Allow an astropy table column for wavelengths in from_tuple

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Bug fixes
 .........
 
 - Fix `XSpectrum1D.from_tuple` to allow an astropy table column to
-  specify wavelengths.
+  specify wavelengths and fluxes.
 
 
 0.1 (2016-01-31)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,11 @@
 0.2 (unreleased)
 ----------------
 
-- No changes yet
+Bug fixes
+.........
+
+- Fix `XSpectrum1D.from_tuple` to allow an astropy table column to
+  specify wavelengths.
 
 
 0.1 (2016-01-31)

--- a/linetools/spectra/tests/test_xspec_init.py
+++ b/linetools/spectra/tests/test_xspec_init.py
@@ -9,6 +9,7 @@ import pdb
 import astropy.io.ascii as ascii
 from astropy import units as u
 from astropy.io import fits
+import astropy.table
 
 from specutils.spectrum1d import Spectrum1D
 
@@ -42,6 +43,14 @@ def test_from_tuple():
     co = None
     spec = XSpectrum1D.from_tuple((idl['wave'],idl['flux'],idl['sig'], co))
     np.testing.assert_allclose(spec.wavelength.value, idl['wave'])
+
+def test_from_tuple_array():
+    wv = astropy.table.Column(np.arange(10.), name='wave', unit=None)
+    fx = np.ones(len(wv))
+    sig = np.ones(len(fx))
+    spec = XSpectrum1D.from_tuple((wv, fx, sig))
+    assert spec.wavelength.unit == u.Angstrom
+
 
 """
 # From file

--- a/linetools/spectra/tests/test_xspec_init.py
+++ b/linetools/spectra/tests/test_xspec_init.py
@@ -44,9 +44,9 @@ def test_from_tuple():
     spec = XSpectrum1D.from_tuple((idl['wave'],idl['flux'],idl['sig'], co))
     np.testing.assert_allclose(spec.wavelength.value, idl['wave'])
 
-def test_from_tuple_array():
+def test_from_tuple_Column():
     wv = astropy.table.Column(np.arange(10.), name='wave', unit=None)
-    fx = np.ones(len(wv))
+    fx = astropy.table.Column(np.ones(len(wv)), name='flux', unit=None)
     sig = np.ones(len(fx))
     spec = XSpectrum1D.from_tuple((wv, fx, sig))
     assert spec.wavelength.unit == u.Angstrom

--- a/linetools/spectra/xspectrum1d.py
+++ b/linetools/spectra/xspectrum1d.py
@@ -108,7 +108,10 @@ class XSpectrum1D(object):
         else:
             if fx_unit is None:
                 fx_unit = u.dimensionless_unscaled
-            iflux = ituple[1].value
+            try:
+                iflux = ituple[1].value
+            except AttributeError:
+                iflux = ituple[1]
 
         # Sort and append None
         ltuple = list(ituple)

--- a/linetools/spectra/xspectrum1d.py
+++ b/linetools/spectra/xspectrum1d.py
@@ -94,7 +94,10 @@ class XSpectrum1D(object):
         else:
             if wv_unit is None:
                 wv_unit = u.AA
-            iwave = ituple[0].value
+            try:
+                iwave = ituple[0].value
+            except AttributeError:
+                iwave = ituple[0]
 
         # Parse flux
         try:


### PR DESCRIPTION
Fixes a bug in `from_tuple` if the input wavelength array object has a `unit` attribute but no `value` attribute (which is possible for astropy table columns.) 