### PR TITLE
Remove a specutils import

### DIFF
--- a/linetools/isgm/abscomponent.py
+++ b/linetools/isgm/abscomponent.py
@@ -18,7 +18,7 @@ from astropy.units import Quantity
 from astropy.coordinates import SkyCoord
 from astropy.table import QTable, Column
 
-from specutils import Spectrum1D
+from linetools.spectrum.xspectrum1d import XSpectrum1D
 
 from linetools.analysis import absline as ltaa
 from linetools.analysis import plots as ltap
@@ -319,7 +319,7 @@ class AbsComponent(object):
         # Check for spec
         gdiline = []
         for iline in self._abslines:
-            if isinstance(iline.analy['spec'], Spectrum1D):
+            if isinstance(iline.analy['spec'], XSpectrum1D):
                 gdiline.append(iline)
         nplt = len(gdiline)
         if nplt == 0:

--- a/linetools/isgm/abscomponent.py
+++ b/linetools/isgm/abscomponent.py
@@ -18,8 +18,7 @@ from astropy.units import Quantity
 from astropy.coordinates import SkyCoord
 from astropy.table import QTable, Column
 
-from linetools.spectrum.xspectrum1d import XSpectrum1D
-
+from linetools.spectra.xspectrum1d import XSpectrum1D
 from linetools.analysis import absline as ltaa
 from linetools.analysis import plots as ltap
 from linetools.spectralline import AbsLine, SpectralLine

--- a/linetools/spectra/xspectrum1d.py
+++ b/linetools/spectra/xspectrum1d.py
@@ -690,7 +690,7 @@ or QtAgg backends to enable all interactive plotting commands.
         return ((self.wavelength - wv_obs) * const.c / wv_obs).to('km/s')
 
     #  Box car smooth
-    def box_smooth(self, nbox, preserve=False. **kwargs):
+    def box_smooth(self, nbox, preserve=False, **kwargs):
         """ Box car smooth the spectrum
 
         Parameters

--- a/linetools/spectra/xspectrum1d.py
+++ b/linetools/spectra/xspectrum1d.py
@@ -690,7 +690,7 @@ or QtAgg backends to enable all interactive plotting commands.
         return ((self.wavelength - wv_obs) * const.c / wv_obs).to('km/s')
 
     #  Box car smooth
-    def box_smooth(self, nbox, preserve=False):
+    def box_smooth(self, nbox, preserve=False. **kwargs):
         """ Box car smooth the spectrum
 
         Parameters
@@ -700,6 +700,9 @@ or QtAgg backends to enable all interactive plotting commands.
         preserve: bool (False)
           If True, perform a convolution to ensure the new spectrum
           has the same number of pixels as the original.
+        **kwargs: dict
+          If preserve=True, these keywords are passed on to
+          astropy.convoution.convolve
 
         Returns
         -------
@@ -707,8 +710,8 @@ or QtAgg backends to enable all interactive plotting commands.
         """
         if preserve:
             from astropy.convolution import convolve, Box1DKernel
-            new_fx = convolve(self.flux, Box1DKernel(nbox))
-            new_sig = convolve(self.sig, Box1DKernel(nbox))
+            new_fx = convolve(self.flux, Box1DKernel(nbox), **kwargs)
+            new_sig = convolve(self.sig, Box1DKernel(nbox), **kwargs)
             new_wv = self.wavelength
         else:
             # Truncate arrays as need be


### PR DESCRIPTION
Also allow passing arbitrary keyword arguments to XSpectrum1D.box_smooth(), to be passed on to astropy.convolution.convolve.