### PR TITLE
SpecLine Items

### DIFF
--- a/docs/examples/AbsLine_examples.ipynb
+++ b/docs/examples/AbsLine_examples.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
@@ -23,7 +23,8 @@
     "import astropy.units as u\n",
     "from linetools.spectralline import AbsLine, SpectralLine\n",
     "from linetools import spectralline as ltsp\n",
-    "from linetools.spectra.xspectrum1d import XSpectrum1D"
+    "from linetools.spectra.xspectrum1d import XSpectrum1D\n",
+    "from linetools.spectra import io as lsio"
    ]
   },
   {
@@ -35,36 +36,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
    "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "linetools.lists.parse: Reading linelist --- \n",
-      "   /Users/ncrighton/Code/Repo/linetools/build/lib.macosx-10.5-x86_64-3.4/linetools/data/lines/morton03_table2.fits.gz\n",
-      "linetools.lists.parse: Reading linelist --- \n",
-      "   /Users/ncrighton/Code/Repo/linetools/build/lib.macosx-10.5-x86_64-3.4/linetools/data/lines/morton00_table2.fits.gz\n",
-      "linetools.lists.parse: Reading linelist --- \n",
-      "   /Users/ncrighton/Code/Repo/linetools/build/lib.macosx-10.5-x86_64-3.4/linetools/data/lines/verner96_tab1.fits.gz\n",
-      "linetools.lists.parse: Reading linelist --- \n",
-      "   /Users/ncrighton/Code/Repo/linetools/build/lib.macosx-10.5-x86_64-3.4/linetools/data/lines/verner94_tab6.fits\n",
-      "linetools.lists.parse: Reading linelist --- \n",
-      "   /Users/ncrighton/Code/Repo/linetools/build/lib.macosx-10.5-x86_64-3.4/linetools/data/lines/EUV_lines.ascii\n",
-      "read_sets: Using set file -- \n",
-      "  /Users/ncrighton/Code/Repo/linetools/build/lib.macosx-10.5-x86_64-3.4/linetools/lists/sets/llist_v1.0.ascii\n"
-     ]
-    },
     {
      "data": {
       "text/plain": [
        "<AbsLine: CIV 1548, wrest=1548.1950 Angstrom>"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 2,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -83,7 +66,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 3,
    "metadata": {
     "collapsed": false
    },
@@ -109,6 +92,9 @@
        " 'gk': 4,\n",
        " 'group': 1,\n",
        " 'ion': 4,\n",
+       " 'is_EUV': False,\n",
+       " 'is_HI': False,\n",
+       " 'is_Strong': True,\n",
        " 'mol': '',\n",
        " 'name': 'CIV 1548',\n",
        " 'nj': 0,\n",
@@ -116,7 +102,7 @@
        " 'wrest': <Quantity 1548.195 Angstrom>}"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -134,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
@@ -142,55 +128,58 @@
     {
      "data": {
       "text/plain": [
-       "{'analy': {'datafile': '',\n",
-       "  'do_analysis': 1,\n",
-       "  'flag_kin': 0,\n",
-       "  'flg_eye': 0,\n",
-       "  'flg_limit': 0,\n",
-       "  'name': 'CIV 1548',\n",
-       "  'vlim': {'unit': 'km / s', 'value': [0.0, 0.0]},\n",
-       "  'wvlim': {'unit': 'Angstrom', 'value': [0.0, 0.0]}},\n",
-       " 'attrib': {'DEC': 0.0,\n",
-       "  'EW': {'unit': 'Angstrom', 'value': 0.0},\n",
-       "  'N': {'unit': '1 / cm2', 'value': 0.0},\n",
-       "  'RA': 0.0,\n",
-       "  'b': {'unit': 'km / s', 'value': 0.0},\n",
-       "  'flag_EW': 0,\n",
-       "  'flag_N': 0,\n",
-       "  'sig_EW': {'unit': 'Angstrom', 'value': 0.0},\n",
-       "  'sig_N': {'unit': '1 / cm2', 'value': 0.0},\n",
-       "  'sig_b': {'unit': 'km / s', 'value': 0.0},\n",
-       "  'sig_v': {'unit': 'km / s', 'value': 0.0},\n",
-       "  'sig_z': 0.0,\n",
-       "  'v': {'unit': 'km / s', 'value': 0.0},\n",
-       "  'z': 0.0},\n",
-       " 'data': {'A': {'unit': '1 / s', 'value': 0.0},\n",
+       "{'analy': {u'datafile': u'',\n",
+       "  u'do_analysis': 1,\n",
+       "  u'flag_kin': 0,\n",
+       "  u'flg_eye': 0,\n",
+       "  u'flg_limit': 0,\n",
+       "  u'name': 'CIV 1548',\n",
+       "  u'vlim': {'unit': u'km / s', 'value': [0.0, 0.0]},\n",
+       "  u'wvlim': {'unit': u'Angstrom', 'value': [0.0, 0.0]}},\n",
+       " 'attrib': {u'DEC': 0.0,\n",
+       "  u'EW': {'unit': u'Angstrom', 'value': 0.0},\n",
+       "  u'N': {'unit': u'1 / cm2', 'value': 0.0},\n",
+       "  u'RA': 0.0,\n",
+       "  u'b': {'unit': u'km / s', 'value': 0.0},\n",
+       "  u'flag_EW': 0,\n",
+       "  u'flag_N': 0,\n",
+       "  u'sig_EW': {'unit': u'Angstrom', 'value': 0.0},\n",
+       "  u'sig_N': {'unit': u'1 / cm2', 'value': 0.0},\n",
+       "  u'sig_b': {'unit': u'km / s', 'value': 0.0},\n",
+       "  u'sig_v': {'unit': u'km / s', 'value': 0.0},\n",
+       "  u'sig_z': 0.0,\n",
+       "  u'v': {'unit': u'km / s', 'value': 0.0},\n",
+       "  u'z': 0.0},\n",
+       " 'data': {'A': {'unit': u'1 / s', 'value': 0.0},\n",
        "  'Am': 0,\n",
-       "  'Ej': {'unit': '1 / cm', 'value': 0.0},\n",
-       "  'Ek': {'unit': '1 / cm', 'value': 0.0},\n",
-       "  'Ex': {'unit': '1 / cm', 'value': 0.0},\n",
+       "  'Ej': {'unit': u'1 / cm', 'value': 0.0},\n",
+       "  'Ek': {'unit': u'1 / cm', 'value': 0.0},\n",
+       "  'Ex': {'unit': u'1 / cm', 'value': 0.0},\n",
        "  'Jj': 0.0,\n",
        "  'Jk': 0.0,\n",
        "  'Ref': 'Verner1994',\n",
        "  'Z': 6,\n",
        "  'el': 0,\n",
-       "  'f': 0.18999999761581421,\n",
-       "  'gamma': {'unit': '1 / s', 'value': 0.0},\n",
+       "  'f': 0.1899999976158142,\n",
+       "  'gamma': {'unit': u'1 / s', 'value': 0.0},\n",
        "  'gj': 2,\n",
        "  'gk': 4,\n",
        "  'group': 1,\n",
        "  'ion': 4,\n",
+       "  'is_EUV': False,\n",
+       "  'is_HI': False,\n",
+       "  'is_Strong': True,\n",
        "  'mol': '',\n",
        "  'name': 'CIV 1548',\n",
        "  'nj': 0,\n",
        "  'nk': 0,\n",
-       "  'wrest': {'unit': 'Angstrom', 'value': 1548.195}},\n",
-       " 'ltype': 'Abs',\n",
+       "  'wrest': {'unit': u'Angstrom', 'value': 1548.195}},\n",
+       " 'ltype': u'Abs',\n",
        " 'name': 'CIV 1548',\n",
-       " 'wrest': {'unit': 'Angstrom', 'value': 1548.195}}"
+       " 'wrest': {'unit': u'Angstrom', 'value': 1548.195}}"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -210,7 +199,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "metadata": {
     "collapsed": false
    },
@@ -221,7 +210,7 @@
        "<AbsLine: CIV 1548, wrest=1548.1950 Angstrom>"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -240,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 6,
    "metadata": {
     "collapsed": false
    },
@@ -252,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 7,
    "metadata": {
     "collapsed": true
    },
@@ -264,7 +253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -292,11 +281,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 9,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'lsio' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-9-a31140691722>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mabslin\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0manaly\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'wvlim'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;36m0.\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m0.\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0mu\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mAA\u001b[0m \u001b[0;31m# Zero out for test\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;31m#\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mabslin\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0manaly\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'spec'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mlsio\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreadspec\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'../../linetools/spectra/tests/files/UM184_nF.fits'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0mabslin\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0manaly\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'vlim'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;36m150.\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m150.\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0mu\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mkm\u001b[0m\u001b[0;34m/\u001b[0m\u001b[0mu\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0ms\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mabslin\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mattrib\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'z'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m2.92929\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'lsio' is not defined"
+     ]
+    }
+   ],
    "source": [
     "abslin.analy['wvlim'] = [0.,0.]*u.AA # Zero out for test\n",
     "#\n",
@@ -338,21 +339,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 2",
    "language": "python",
-   "name": "python3"
+   "name": "python2"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 3
+    "version": 2
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.4.4"
+   "pygments_lexer": "ipython2",
+   "version": "2.7.11"
   }
  },
  "nbformat": 4,

--- a/docs/examples/AbsLine_examples.ipynb
+++ b/docs/examples/AbsLine_examples.ipynb
@@ -4,12 +4,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Examples for AbsLine class (v1.2)"
+    "# Examples for AbsLine class (v1.3)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false
    },
@@ -224,12 +224,88 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Measure an EW"
+    "### Grab data"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$1548.195 \\; \\mathrm{\\mathring{A}}$"
+      ],
+      "text/plain": [
+       "<Quantity 1548.195 Angstrom>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "abslin['wrest']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.18999999761581421"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "abslin.data['f']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('CIV 1548', 0.18999999761581421)"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "abslin['name'], abslin['f']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Measure an EW"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -241,7 +317,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 10,
    "metadata": {
     "collapsed": true
    },
@@ -253,7 +329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 11,
    "metadata": {
     "collapsed": false
    },
@@ -273,6 +349,31 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/latex": [
+       "$0.9935021 \\; \\mathrm{\\mathring{A}}$"
+      ],
+      "text/plain": [
+       "<Quantity 0.9935021012055584 Angstrom>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "abslin['EW']"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -281,23 +382,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 13,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "ename": "NameError",
-     "evalue": "name 'lsio' is not defined",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-9-a31140691722>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0mabslin\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0manaly\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'wvlim'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;36m0.\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m0.\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0mu\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mAA\u001b[0m \u001b[0;31m# Zero out for test\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;31m#\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mabslin\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0manaly\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'spec'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mlsio\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreadspec\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'../../linetools/spectra/tests/files/UM184_nF.fits'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0mabslin\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0manaly\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'vlim'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0;36m150.\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m150.\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0mu\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mkm\u001b[0m\u001b[0;34m/\u001b[0m\u001b[0mu\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0ms\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mabslin\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mattrib\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'z'\u001b[0m\u001b[0;34m]\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m2.92929\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mNameError\u001b[0m: name 'lsio' is not defined"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "abslin.analy['wvlim'] = [0.,0.]*u.AA # Zero out for test\n",
     "#\n",
@@ -308,7 +397,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 14,
    "metadata": {
     "collapsed": false
    },
@@ -329,12 +418,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {
-    "collapsed": true
+    "collapsed": false
    },
-   "outputs": [],
-   "source": []
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "13.905089739914704"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "abslin['logN']"
+   ]
   }
  ],
  "metadata": {

--- a/docs/specline.rst
+++ b/docs/specline.rst
@@ -47,6 +47,13 @@ EW flag          attrib['flag_EW'] int       Equivalent width flag
 
 .. _specanalysis
 
+You can access these attributes with a getitem call, e.g.::
+
+   specline['EW']
+
+A search is performed through the object attributes (e.g. wrest),
+the attrib dict, the analy dict, and then the data dict.
+
 Analysis
 ========
 
@@ -54,9 +61,9 @@ It is common that one wishes to associate a line with a spectrum
 to perform a range of analyses.
 This is accomplished through::
 
-   spline.analy['spec'] = sp
+   specline.analy['spec'] = spec
 
-where sp is an :ref:`XSpectrum1D` object.
+where spec is an :ref:`XSpectrum1D` object.
 
 Methods
 =======
@@ -72,7 +79,7 @@ to the line's redshift.  The code returns the flux, error array,
 and a *dict* containing the wavelength and velocity arrays.
 ::
 
-   spline.analy['vlim'] = [-300., 300.]*u.km/u.s
+   specline.analy['vlim'] = [-300., 300.]*u.km/u.s
    fx, sig, wv_dict = spline.cut_spec()
 
 ismatch
@@ -127,7 +134,7 @@ be easily written to the disk, e.g.::
 
    adict = specline.to_dict()
    with io.open(outfil, 'w', encoding='utf-8') as f:
-      f.write(unicode(json.dumps(tdict, sort_keys=True,
-         indent=4, separators=(',', ': '))))
+      f.write(json.dumps(tdict, sort_keys=True,
+         indent=4, separators=(',', ': ')))
 
 

--- a/linetools/isgm/abssystem.py
+++ b/linetools/isgm/abssystem.py
@@ -312,7 +312,6 @@ class AbsSystem(object):
         else:
             return [abslines[ii] for ii in mt]
 
-
     def get_comp_from_absline(self, aline):
         """ Returns the component that holds the input AbsLine
 

--- a/linetools/spectralline.py
+++ b/linetools/spectralline.py
@@ -543,7 +543,23 @@ class AbsLine(SpectralLine):
         # Log
         laa.log_clm(self.attrib)
 
-    # Output
+    def __getitem__(self, k):
+        """  Passback a data bit from the Line
+        """
+        try:
+            return getattr(self,k)
+        except AttributeError:
+            try:
+                return self.attrib[k]
+            except KeyError:
+                try:
+                    return self.analy[k]
+                except KeyError:
+                    try:
+                        return self.data[k]
+                    except KeyError:
+                        return None
+
     def __repr__(self):
         txt = '<{:s}:'.format(self.__class__.__name__)
         # Name

--- a/linetools/tests/test_init_absline.py
+++ b/linetools/tests/test_init_absline.py
@@ -11,24 +11,20 @@ from astropy import units as u
 from linetools.spectralline import AbsLine, SpectralLine
 from linetools import utils as ltu
 
-'''
-def data_path(filename):
-    data_dir = os.path.join(os.path.dirname(__file__), 'files')
-    return os.path.join(data_dir, filename)
-'''
 
 def test_mk_absline():
-	# Init HI Lya
+    # Init HI Lya
     abslin = AbsLine(1215.6700*u.AA)
     np.testing.assert_allclose(abslin.data['f'], 0.4164)
 
-	# Init CII 1334 with LineList
+    # Init CII 1334 with LineList
     abslin2 = AbsLine(1334.5323*u.AA, linelist='Strong')
     np.testing.assert_allclose(abslin2.data['Ek'], 74932.62 / u.cm)
 
-	# Init CII 1334 by name
+    # Init CII 1334 by name
     abslin3 = AbsLine('CII 1334')
     np.testing.assert_allclose(abslin3.data['wrest'], 1334.5323*u.AA)
+
 
 def test_dicts():
     # Init HI Lya
@@ -42,3 +38,10 @@ def test_dicts():
     newdict = ltu.loadjson('tmp.json')
     newlin = SpectralLine.from_dict(newdict)
     assert newlin.name == 'HI 1215'
+
+
+def test_getitem():
+    abslin = AbsLine(1215.6700*u.AA)
+    assert abslin['name'] == 'HI 1215'
+    np.testing.assert_allclose(abslin['f'], 0.4164)
+


### PR DESCRIPTION
Enables one to grab items from a Specline by
overloading get_item, e.g.

absline['EW']

instead of 

absline.attrib['EW']

Just for convenience

Tests and docs too