### PR TITLE
Remove numpy 1.9 from travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,8 @@ matrix:
           env: SETUP_CMD='test'
 
         # Try older numpy versions.
-        - python: 2.7
-          env: NUMPY_VERSION=1.9 SETUP_CMD='test'
+        # - python: 2.7
+        # env: NUMPY_VERSION=1.9 SETUP_CMD='test'
 
 before_install:
 


### PR DESCRIPTION
There's a problem with travis testing of numpy version 1.9, so this removes that test. I don't think we need to worry about supporting 1.9 anymore anyway, later stable versions are now in anaconda.