### PR TITLE
AbsSystem edits

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -19,7 +19,7 @@ We strongly recommend that you use `Anaconda
 <https://www.continuum.io/downloads>`_ to install them. With Anaconda
 you can check for the presence and versions of the dependencies with::
 
-  conda list "^python$|numpy|astropy$|scipy$|matplotlib|PyQT|h5py"
+  conda list "^python|numpy|astropy|scipy|matplotlib|PyQT|h5py"
 
 If you're missing any, install them with (for example)::
 

--- a/linetools/isgm/abssystem.py
+++ b/linetools/isgm/abssystem.py
@@ -294,6 +294,12 @@ class AbsSystem(object):
             self._components.append(abscomp)
         else:
             warnings.warn('Input AbsComponent with Zion={} does not match AbsSystem rules. Not appending'.format(abscomp.Zion))
+            if not testcoord:
+                warnings.warn('Failed coordinate match')
+            if not testcomp:
+                warnings.warn('Failed component check')
+            if not testz:
+                warnings.warn('Failed velocity overlap')
         #
         return test
 

--- a/linetools/isgm/abssystem.py
+++ b/linetools/isgm/abssystem.py
@@ -458,15 +458,21 @@ class AbsSystem(object):
         for comp in self._components:
             comp.synthesize_colm(**kwargs)
 
-    def stack_plot(self, **kwargs):
+    def stack_plot(self, pvlim=None, **kwargs):
         """Show a stack plot of the system, if spec are loaded
         Assumes the data are normalized.
 
         Parameters
         ----------
+        pvlim : Quantities, optional
+          Over-ride system vlim for plotting
         """
         from linetools.analysis import plots as ltap
-        ltap.stack_plot(self.list_of_abslines(), vlim=self.vlim, **kwargs)
+        if pvlim is not None:
+            vlim = pvlim
+        else:
+            vlim = self.vlim
+        ltap.stack_plot(self.list_of_abslines(), vlim=vlim, **kwargs)
 
     def to_dict(self):
         """ Write AbsSystem data to a dict that can be written with JSON


### PR DESCRIPTION
Warnings

pvlim in stack_plot()

Failing things in Python 3.5
  Anyone know why??