### PR TITLE
Abscomp utils: group_coincident_components()

### DIFF
--- a/linetools/isgm/tests/test_use_abscomp.py
+++ b/linetools/isgm/tests/test_use_abscomp.py
@@ -276,6 +276,7 @@ def test_get_wvobs_chunks():
     abscomp._abslines[0].analy['wvlim'] = [1,0]*u.AA
     wvobs_chunks = ltiu.get_wvobs_chunks(abscomp)
 
+
 def test_coincident_components():
     abscomp, HIlines = mk_comp('HI', zcomp=2.92939)
     SiIIcomp1,_ = mk_comp('SiII',vlim=[50.,300.]*u.km/u.s, zcomp=2.92939)
@@ -287,3 +288,12 @@ def test_coincident_components():
         a = ltiu.coincident_components('not_a_component', SiIIcomp1)
     with pytest.raises(ValueError):
         a = ltiu.coincident_components(abscomp, 'not_a_component')
+
+
+# def test_group_coincident_compoments():
+if 1:
+    abscomp, HIlines = mk_comp('HI', zcomp=2.92939)
+    SiIIcomp1, _ = mk_comp('SiII',vlim=[50.,300.]*u.km/u.s, zcomp=2.92939)
+    SiIIcomp2, _ = mk_comp('SiII',vlim=[-300.,0.]*u.km/u.s, zcomp=2.92939)
+    comp_list = [abscomp, abscomp, SiIIcomp1, abscomp, SiIIcomp2, abscomp, SiIIcomp1, SiIIcomp2]
+    out = ltiu.group_coincident_compoments(comp_list)

--- a/linetools/isgm/tests/test_use_abscomp.py
+++ b/linetools/isgm/tests/test_use_abscomp.py
@@ -295,5 +295,19 @@ if 1:
     abscomp, HIlines = mk_comp('HI', zcomp=2.92939)
     SiIIcomp1, _ = mk_comp('SiII',vlim=[50.,300.]*u.km/u.s, zcomp=2.92939)
     SiIIcomp2, _ = mk_comp('SiII',vlim=[-300.,0.]*u.km/u.s, zcomp=2.92939)
+    # reset names for easy testing
+    abscomp.name = 'HI'
+    SiIIcomp1.name = 'SiII_1'
+    SiIIcomp2.name = 'SiII_2'
     comp_list = [abscomp, abscomp, SiIIcomp1, abscomp, SiIIcomp2, abscomp, SiIIcomp1, SiIIcomp2]
     out = ltiu.group_coincident_compoments(comp_list)
+    assert len(out) == 3  # only three groups
+    out_names_0 = [comp.name for comp in out[0]]  # these should be only HI in group 0, and 4 of them
+    assert np.sum([n == 'HI' for n in out_names_0]) == 4
+    assert len(out[0]) == 4
+    out_names = [[],[],[]]
+    for ii in range(len(out)):
+        for comp in out[ii]:
+            out_names[ii] += [comp.name]
+    assert out_names == [['HI', 'HI', 'HI', 'HI'], ['SiII_1', 'SiII_1'], ['SiII_2', 'SiII_2']]
+

--- a/linetools/isgm/tests/test_use_abscomp.py
+++ b/linetools/isgm/tests/test_use_abscomp.py
@@ -310,4 +310,9 @@ if 1:
         for comp in out[ii]:
             out_names[ii] += [comp.name]
     assert out_names == [['HI', 'HI', 'HI', 'HI'], ['SiII_1', 'SiII_1'], ['SiII_2', 'SiII_2']]
-
+    # now a case where are all different
+    comp_list = [abscomp, SiIIcomp1, SiIIcomp2]
+    out = ltiu.group_coincident_compoments(comp_list)
+    for a,b in zip(comp_list, out):
+        assert len(b) == 1
+        assert a == b[0]

--- a/linetools/isgm/tests/test_use_abscomp.py
+++ b/linetools/isgm/tests/test_use_abscomp.py
@@ -315,3 +315,6 @@ def test_group_coincident_compoments():
     for a,b in zip(comp_list, out):
         assert len(b) == 1
         assert a == b[0]
+    # check output as dictionary
+    out = ltiu.group_coincident_compoments(comp_list, output_type='dict')
+    assert isinstance(out, dict)

--- a/linetools/isgm/tests/test_use_abscomp.py
+++ b/linetools/isgm/tests/test_use_abscomp.py
@@ -290,8 +290,7 @@ def test_coincident_components():
         a = ltiu.coincident_components(abscomp, 'not_a_component')
 
 
-# def test_group_coincident_compoments():
-if 1:
+def test_group_coincident_compoments():
     abscomp, HIlines = mk_comp('HI', zcomp=2.92939)
     SiIIcomp1, _ = mk_comp('SiII',vlim=[50.,300.]*u.km/u.s, zcomp=2.92939)
     SiIIcomp2, _ = mk_comp('SiII',vlim=[-300.,0.]*u.km/u.s, zcomp=2.92939)

--- a/linetools/isgm/utils.py
+++ b/linetools/isgm/utils.py
@@ -516,15 +516,21 @@ def group_coincident_compoments(comp_list):
                 pass
 
     # Now we have out as a list of lists with indices, or empty lists
-    # So lets produce the final output from it
+    # let's get rid of the empty lists
+    out = [x for x in out if x != []]
+
+    # Now lets produce the final output from it
     output_list = []
+    output_dict = {}
     for ii in range(len(out)):
-        if len(out[ii]) == 0:
-            continue
         aux_list = []
         for jj in out[ii]:
             aux_list += [comp_list[jj]]
+        output_dict['{}'.format(ii)] = aux_list
         output_list += [aux_list]
+
+    # choose between dict of list
+    # return output_dict
     return output_list
 
 

--- a/linetools/isgm/utils.py
+++ b/linetools/isgm/utils.py
@@ -475,7 +475,7 @@ def group_coincident_compoments(comp_list, output_type='list'):
         in the output.
     """
     if output_type not in ['list', 'dict', 'dictionary']:
-        raise ValueError("`output_type` must be either 'list' or 'dict'".)
+        raise ValueError("`output_type` must be either 'list' or 'dict'.")
 
     # the first extreme case is that all components are independent
     # of each other, in which case we have the following output shape

--- a/linetools/isgm/utils.py
+++ b/linetools/isgm/utils.py
@@ -455,9 +455,9 @@ def coincident_components(comp1, comp2, tol=0.2*u.arcsec):
 
 
 def group_coincident_compoments(comp_list):
-    """For a given input list of component, this function
-    group together components that are coincident to each other
-    (including by transitivity), and return them as a list of
+    """For a given input list of components, this function
+    groups together components that are coincident to each other
+    (including by transitivity), and returns them as a list of
     component lists.
 
     Parameters
@@ -491,8 +491,7 @@ def group_coincident_compoments(comp_list):
         for jj in range(ii+1, len(comp_list)):
             # print(ii,jj)
             comp_jj = comp_list[jj]
-            overlap_ii_jj = coincident_components(comp_ii, comp_jj)
-            if overlap_ii_jj is True:
+            if coincident_components(comp_ii, comp_jj):  # There is overlap between comp_ii and comp_jj
                 # check in the previous ones where does jj belongs to
                 switch = 0
                 for kk in range(len(out[:ii])):

--- a/linetools/isgm/utils.py
+++ b/linetools/isgm/utils.py
@@ -471,8 +471,6 @@ def group_coincident_compoments(comp_list):
         The grouped components as individual lists
         in the output list.
     """
-    groups = dict()
-    counter = 0
     # the first extreme case is that all components are independent
     # of each other, in which case we have the following output shape
     out = [[] for kk in range(len(comp_list))]
@@ -518,8 +516,8 @@ def group_coincident_compoments(comp_list):
             else:
                 pass
 
-    # Now we wave out as a list of lists with indices or empty lists
-    # So lets produce the final output
+    # Now we have out as a list of lists with indices, or empty lists
+    # So lets produce the final output from it
     output_list = []
     for ii in range(len(out)):
         if len(out[ii]) == 0:

--- a/linetools/isgm/utils.py
+++ b/linetools/isgm/utils.py
@@ -454,23 +454,29 @@ def coincident_components(comp1, comp2, tol=0.2*u.arcsec):
     return False
 
 
-def group_coincident_compoments(comp_list):
+def group_coincident_compoments(comp_list, output_type='list'):
     """For a given input list of components, this function
     groups together components that are coincident to each other
-    (including by transitivity), and returns them as a list of
-    component lists.
+    (including by transitivity), and returns them as a list (default)
+    or dictionary of component lists.
 
     Parameters
     ----------
     comp_list : list of AbsComponent
         Input list of components to group
+    output_type : str, optional
+        Type of the output, choose either
+        'list' for list or 'dict' for dictionary.
 
     Returns
     -------
-    output : list of lists of AbsComponent
+    output : list (or dictionary) of lists of AbsComponent
         The grouped components as individual lists
-        in the output list.
+        in the output.
     """
+    if output_type not in ['list', 'dict', 'dictionary']:
+        raise ValueError("`output_type` must be either 'list' or 'dict'".)
+
     # the first extreme case is that all components are independent
     # of each other, in which case we have the following output shape
     out = [[] for kk in range(len(comp_list))]
@@ -530,7 +536,9 @@ def group_coincident_compoments(comp_list):
         output_list += [aux_list]
 
     # choose between dict of list
-    # return output_dict
-    return output_list
+    if output_type == 'list':
+        return output_list
+    elif output_type in ['dict', 'dictionary']:
+        return output_dict
 
 

--- a/linetools/isgm/utils.py
+++ b/linetools/isgm/utils.py
@@ -452,3 +452,82 @@ def coincident_components(comp1, comp2, tol=0.2*u.arcsec):
             if overlap is True:
                 return True
     return False
+
+
+def group_coincident_compoments(comp_list):
+    """For a given input list of component, this function
+    group together components that are coincident to each other
+    (including by transitivity), and return them as a list of
+    component lists.
+
+    Parameters
+    ----------
+    comp_list : list of AbsComponent
+        Input list of components to group
+
+    Returns
+    -------
+    output : list of lists of AbsComponent
+        The grouped components as individual lists
+        in the output list.
+    """
+    groups = dict()
+    counter = 0
+    # the first extreme case is that all components are independent
+    # of each other, in which case we have the following output shape
+    out = [[] for kk in range(len(comp_list))]
+
+    for ii in range(len(comp_list)):
+        comp_ii = comp_list[ii]
+        # only append if ii does not belong to a previous round
+        switch = 0
+        for kk in range(len(out[:ii])):
+            if ii in out[kk]:
+                switch = 1
+                break
+        if switch == 1:
+            pass
+        else:
+            out[ii].append(ii)
+
+        for jj in range(ii+1, len(comp_list)):
+            # print(ii,jj)
+            comp_jj = comp_list[jj]
+            overlap_ii_jj = coincident_components(comp_ii, comp_jj)
+            if overlap_ii_jj is True:
+                # check in the previous ones where does jj belongs to
+                switch = 0
+                for kk in range(len(out[:ii])):
+                    if ii in out[kk]:  # this means ii already belongs to out[kk]
+                        # so jj should also go there...(if not there already)
+                        if jj in out[kk]:
+                            pass
+                        else:
+                            out[kk].append(jj)
+                        switch = 1  # for not appending jj again
+                        break
+                if switch == 1:
+                    pass  # this jj was appended already
+                else:
+                    # but check is not already there...
+                    if jj in out[ii]:
+                        pass
+                    else:
+                        out[ii].append(jj)
+                # print(out)
+            else:
+                pass
+
+    # Now we wave out as a list of lists with indices or empty lists
+    # So lets produce the final output
+    output_list = []
+    for ii in range(len(out)):
+        if len(out[ii]) == 0:
+            continue
+        aux_list = []
+        for jj in out[ii]:
+            aux_list += [comp_list[jj]]
+        output_list += [aux_list]
+    return output_list
+
+


### PR DESCRIPTION
- group_coincident_components() implemented
- with test

This function will be useful for VP fitting a full spectrum, where components that are isolated are easy to identify, and so those that are coincident in wobs with others. It may be a bit of a pain to review it...