### PR TITLE
box_smooth failed if there was no error array and preserve was set to True

### DIFF
--- a/linetools/spectra/xspectrum1d.py
+++ b/linetools/spectra/xspectrum1d.py
@@ -938,6 +938,8 @@ class XSpectrum1D(object):
             new_fx = convolve(self.flux, Box1DKernel(nbox), **kwargs)
             if self.sig_is_set:
                 new_sig = convolve(self.sig, Box1DKernel(nbox), **kwargs)
+            else:
+                new_sig = None
             new_sig = convolve(self.sig, Box1DKernel(nbox), **kwargs)
             new_wv = self.wavelength
         else:

--- a/linetools/spectra/xspectrum1d.py
+++ b/linetools/spectra/xspectrum1d.py
@@ -936,6 +936,8 @@ class XSpectrum1D(object):
         if preserve:
             from astropy.convolution import convolve, Box1DKernel
             new_fx = convolve(self.flux, Box1DKernel(nbox), **kwargs)
+            if self.sig_is_set:
+                new_sig = convolve(self.sig, Box1DKernel(nbox), **kwargs)
             new_sig = convolve(self.sig, Box1DKernel(nbox), **kwargs)
             new_wv = self.wavelength
         else:


### PR DESCRIPTION
box_smooth failed if there was no error array and preserve was set to True

These lines fix this issue: First checks if an error array exists, if so it does the convolution otherwise returns None for the "new" error array