### PR TITLE
Fixing box_smooth when no error array is given

### DIFF
--- a/linetools/spectra/xspectrum1d.py
+++ b/linetools/spectra/xspectrum1d.py
@@ -940,7 +940,6 @@ class XSpectrum1D(object):
                 new_sig = convolve(self.sig, Box1DKernel(nbox), **kwargs)
             else:
                 new_sig = None
-            new_sig = convolve(self.sig, Box1DKernel(nbox), **kwargs)
             new_wv = self.wavelength
         else:
             # Truncate arrays as need be

--- a/linetools/spectra/xspectrum1d.py
+++ b/linetools/spectra/xspectrum1d.py
@@ -938,6 +938,8 @@ class XSpectrum1D(object):
             new_fx = convolve(self.flux, Box1DKernel(nbox), **kwargs)
             if self.sig_is_set:
                 new_sig = convolve(self.sig, Box1DKernel(nbox), **kwargs)
+            else:
+                new_sig = None
             new_sig = convolve(self.sig, Box1DKernel(nbox), **kwargs)
             new_wv = self.wavelength
         else:

--- a/linetools/spectra/xspectrum1d.py
+++ b/linetools/spectra/xspectrum1d.py
@@ -936,6 +936,8 @@ class XSpectrum1D(object):
         if preserve:
             from astropy.convolution import convolve, Box1DKernel
             new_fx = convolve(self.flux, Box1DKernel(nbox), **kwargs)
+            if self.sig_is_set:
+                new_sig = convolve(self.sig, Box1DKernel(nbox), **kwargs)
             new_sig = convolve(self.sig, Box1DKernel(nbox), **kwargs)
             new_wv = self.wavelength
         else:


### PR DESCRIPTION
box_smooth failed when no error array was given and "preserve" was set to True.

These lines fixed that issue by checking first if there is an error array, and setting the new error array (new_sig) to None if self.sig_is_set == False