### PR TITLE
Mask the continuum array that is padded with zeros in normalize

### DIFF
--- a/linetools/spectra/xspectrum1d.py
+++ b/linetools/spectra/xspectrum1d.py
@@ -602,7 +602,11 @@ class XSpectrum1D(object):
                 else:
                     raise ValueError('normalize: Continuum needs to be longer!')
             else:
-                raise ValueError('normalize: Continuum needs to be same length as flux array')
+                try: 
+                    gdp = ~self.data['co'][self.select].mask
+                    self.data['co'][self.select][gdp] = co[gdp]
+                except ValueError:
+                    raise ValueError('normalize: Continuum needs to be same length as flux array')
         else:
             self.co = co
         self.normed = True

--- a/linetools/tests/test_xspectrum1d.py
+++ b/linetools/tests/test_xspectrum1d.py
@@ -1,0 +1,20 @@
+# Module to run test on XSpectrum1D
+
+from __future__ import print_function,absolute_import,division,unicode_literals
+import numpy as np
+import glob,os,sys,copy
+from astropy.table import QTable,table
+from astropy.io import ascii
+from astropy import units as u
+from astropy import constants as const
+from matplotlib import pyplot as plt
+from enigma.qpq import spec as qpqs
+
+datadir = os.getenv('DROPBOX_DIR') + '/QSOPairs/data/'
+spec_dict = qpqs.load_spec(datadir+'ESI_redux/SDSSJ103900.01+502652.8_F.fits.gz')
+
+spec_dict['spec'].normalize(spec_dict['conti'])
+spec_dict['spec'] = spec_dict['spec'].normalized_spec()
+
+plt.plot(spec_dict['spec'].data['flux'].compressed())
+plt.show()


### PR DESCRIPTION
My original rationale was that, the continuum array given should have the same length as the flux array, including the zeros. And I learned this is not preferred. 

So I will have the code apply the mask on the continuum array given. If the masked arrays don't have the same length, a ValueError will be raised. 

The setters for wavelength, flux, sig, co remain unchanged. 

A test module for my changes to the class XSpectrum1D is added. 

