### PR TITLE
Rebin all of the spectra in XSpectrum1D

### DIFF
--- a/docs/xspectrum1d.rst
+++ b/docs/xspectrum1d.rst
@@ -92,7 +92,7 @@ One can collate a list of XSpectrum1D objects into one with collate::
     >>> sp1 = XSpectrum1D.from_file('PH957_f.fits')
     >>> sp2 = XSpectrum1D.from_file('q0002m422.txt.gz')
     >>> sp = linetools.spectra.utils.coolate([sp1,sp2])
-    
+
 
 Plotting
 --------

--- a/docs/xspectrum1d.rst
+++ b/docs/xspectrum1d.rst
@@ -69,7 +69,6 @@ Here are a series of example calls to generate the class::
     >>> sp = XSpectrum1D.from_file('PH957_f.fits')      # From a FITS file
     >>> sp = XSpectrum1D.from_file('q0002m422.txt.gz')  # From an ASCII table
     >>> sp = xspec1.copy()                              # From an XSpectrum1D object
-    >>> sp = XSpectrum1D.from_list(xspec1, xspec2)      # From a list of XSpectrum1D objects
     >>> sp = XSpectrum1D.from_tuple((wa, fl, sig), verbose=False)
 
 There are a number of methods to write a file, e.g.

--- a/docs/xspectrum1d.rst
+++ b/docs/xspectrum1d.rst
@@ -87,6 +87,13 @@ data format of XSpectrum1D.  Here are some examples::
     >>> sp.write('QSO.ascii')                   # Same
 
 
+One can collate a list of XSpectrum1D objects into one with collate::
+
+    >>> sp1 = XSpectrum1D.from_file('PH957_f.fits')
+    >>> sp2 = XSpectrum1D.from_file('q0002m422.txt.gz')
+    >>> sp = linetools.spectra.utils.coolate([sp1,sp2])
+    
+
 Plotting
 --------
 
@@ -107,6 +114,11 @@ is made to conserve S/N.  Generally, neighboring pixels will be
 correlated::
 
     >>> newspec = sp.rebin(new_wv, do_sig=True) # doctest: +SKIP
+
+If the XSpectrum1D object containts multiple spectra, you can rebin
+all of them to the new wavelength array as well::
+
+    >>> newspec = sp.rebin(new_wv, do_sig=True, all=True) # doctest: +SKIP
 
 
 Continuum fitting

--- a/linetools/spectra/tests/test_xspec_io.py
+++ b/linetools/spectra/tests/test_xspec_io.py
@@ -20,7 +20,8 @@ def spec2():
 
 @pytest.fixture
 def specm(spec,spec2):
-    return XSpectrum1D.from_list([spec,spec2])
+    specm = ltsu.collate([spec,spec2])
+    return specm
 
 def data_path(filename):
     data_dir = os.path.join(os.path.dirname(__file__), 'files')

--- a/linetools/spectra/tests/test_xspec_utils.py
+++ b/linetools/spectra/tests/test_xspec_utils.py
@@ -20,7 +20,8 @@ def spec2():
 
 @pytest.fixture
 def specm(spec,spec2):
-    return XSpectrum1D.from_list([spec,spec2])
+    specm = ltsu.collate([spec,spec2])
+    return specm
 
 def data_path(filename):
     data_dir = os.path.join(os.path.dirname(__file__), 'files')
@@ -40,7 +41,7 @@ def test_rebin_to_rest(spec,spec2):
     rest_spec = ltsu.rebin_to_rest(coll_spec, zarr, 100*u.km/u.s, debug=False)
     # Test
     assert rest_spec.totpix == 3716
-    np.testing.assert_allclose(rest_spec.wvmin.value, 986.021738877745, rtol=1e-5)
+    np.testing.assert_allclose(rest_spec.wvmin.value, 986.3506403, rtol=1e-5)
 
 
 def test_smash_spectra(spec,spec2):
@@ -54,7 +55,7 @@ def test_smash_spectra(spec,spec2):
     stack = ltsu.smash_spectra(rest_spec, method='average')
     # Test
     assert stack.totpix == 3716
-    np.testing.assert_allclose(stack.flux[0].value, -1.19753563, rtol=1e-5)
+    np.testing.assert_allclose(stack.flux[1].value, -3.3213510, rtol=1e-5)
 
 
 def test_airtovac_andback(spec):
@@ -72,7 +73,7 @@ def test_airtovac_andback(spec):
     assert spec.meta['airvac'] == 'air'
 
 
-def test_rebin(spec):
+def test_rebin(spec, specm):
     # Rebin
     new_wv = np.arange(3000., 9000., 5) * u.AA
     newspec = spec.rebin(new_wv)
@@ -81,18 +82,15 @@ def test_rebin(spec):
     assert newspec.flux.unit is u.dimensionless_unscaled
     # With sigma
     newspec = spec.rebin(new_wv, do_sig=True)
-    """
-    i1 = np.argmin(np.abs(spec.wavelength-5000.*u.AA))
-    s2n_1 = spec.flux[i1] / spec.sig[i1]
-    i2 = np.argmin(np.abs(newspec.wavelength-5000.*u.AA))
-    s2n_2 = newspec.flux[i2] / newspec.sig[i2]
-    """
     imn = np.argmin(np.abs(newspec.wavelength-8055*u.AA))
     np.testing.assert_allclose(newspec.sig[imn].value, 0.0169634, rtol=1e-5)
     # With NANs
     spec.data['flux'][spec.select][100:110] = np.nan
     newspec = spec.rebin(new_wv)
     np.testing.assert_allclose(newspec.flux[1000], 0.9999280967617779)
+    # All
+    spec2 = specm.rebin(new_wv, all=True)
+    pytest.set_trace()
 
 
 def test_addnoise(spec):

--- a/linetools/spectra/tests/test_xspec_utils.py
+++ b/linetools/spectra/tests/test_xspec_utils.py
@@ -90,7 +90,7 @@ def test_rebin(spec, specm):
     np.testing.assert_allclose(newspec.flux[1000], 0.9999280967617779)
     # All
     spec2 = specm.rebin(new_wv, all=True)
-    pytest.set_trace()
+    np.testing.assert_allclose(spec2.wvmax.value, 8995.0)
 
 
 def test_addnoise(spec):


### PR DESCRIPTION
Rebin all the spectra in an XSpectrum1D object.
Default is the selected on.

Also pushed the rebin method to spectra.utils

And deprecated from_list as it was duplicated by collate()

docs and tests updated