### PR TITLE
dict in meta for XSpectrum1D

### DIFF
--- a/linetools/spectra/io.py
+++ b/linetools/spectra/io.py
@@ -653,7 +653,11 @@ def parse_hdf5(inp, **kwargs):
         meta = json.loads(hdf5[path+'meta'].value)
         # Headers
         for jj,heads in enumerate(meta['headers']):
-            meta['headers'][jj] = fits.Header.fromstring(meta['headers'][jj])
+            try:
+                meta['headers'][jj] = fits.Header.fromstring(meta['headers'][jj])
+            except TypeError:  # dict
+                if not isinstance(meta['headers'][jj], dict):
+                    raise IOError("Bad meta type")
     else:
         meta = None
     # Units

--- a/linetools/spectra/io.py
+++ b/linetools/spectra/io.py
@@ -698,15 +698,18 @@ def parse_DESI_brick(hdulist, select=0):
     """
     fx = hdulist[0].data
     # Sig
-    ivar = hdulist[1].data
-    sig = np.zeros_like(ivar)
-    gdi = ivar > 0.
-    sig[gdi] = np.sqrt(1./ivar[gdi])
+    if hdulist[1].name in ['ERROR', 'SIG']:
+        sig = hdulist[1].data
+    else:
+        ivar = hdulist[1].data
+        sig = np.zeros_like(ivar)
+        gdi = ivar > 0.
+        sig[gdi] = np.sqrt(1./ivar[gdi])
     # Wave
     wave = hdulist[2].data
     wave = give_wv_units(wave)
-    #wave = np.outer(np.ones(fx.shape[0]), wave)
-    wave = np.tile(wave, (fx.shape[0],1))
+    if wave.shape != fx.shape:
+        wave = np.tile(wave, (fx.shape[0],1))
     # Finish
     xspec1d = XSpectrum1D(wave, fx, sig, select=select)
     return xspec1d

--- a/linetools/spectra/tests/test_xspec_io.py
+++ b/linetools/spectra/tests/test_xspec_io.py
@@ -30,6 +30,21 @@ def data_path(filename):
     data_dir = os.path.join(os.path.dirname(__file__), 'files')
     return os.path.join(data_dir, filename)
 
+def test_readwrite_meta_as_dicts(spec):
+    sp = XSpectrum1D.from_tuple((np.array([5,6,7]), np.ones(3), np.ones(3)*0.1))
+    sp.meta['headers'][0] = dict(a=1, b='abc')
+    sp2 = XSpectrum1D.from_tuple((np.array([8,9,10]), np.ones(3), np.ones(3)*0.1))
+    sp2.meta['headers'][0] = dict(c=2, d='efg')
+    spec = ltsu.collate([sp,sp2])
+    # Write
+    spec.write_to_fits(data_path('tmp.fits'))
+    spec.write_to_hdf5(data_path('tmp.hdf5'))
+    # Read and test
+    newspec = io.readspec(data_path('tmp.hdf5'))
+    assert newspec.meta['headers'][0]['a'] == 1
+    assert newspec.meta['headers'][0]['b'] == 'abc'
+    newspec2 = io.readspec(data_path('tmp.fits'))
+    assert 'METADATA' in newspec2.meta['headers'][0].keys()
 
 def test_write(spec,specm):
     # FITS
@@ -105,3 +120,5 @@ def test_readwrite_metadata(spec):
     np.testing.assert_allclose(spec2.meta['c'], d['c'])
     np.testing.assert_allclose(spec2.meta['d'], d['d'])
     assert spec2.meta['e'] == d['e']
+
+

--- a/linetools/spectra/utils.py
+++ b/linetools/spectra/utils.py
@@ -20,6 +20,8 @@ def meta_to_disk(in_meta):
     Parameters
     ----------
     in_meta : dict
+      list in 'headers' needs to be a series of Header objects
+      or a series of dict objects
 
     Returns
     -------
@@ -32,12 +34,15 @@ def meta_to_disk(in_meta):
         if header is None:
             meta['headers'][kk] = str('none')
         else:
-            try:
-                meta['headers'][kk] = header.tostring()
-            except AttributeError:
-                if not isinstance(header, basestring):
-                    raise ValueError("Bad format in header")
-                meta['headers'][kk] = header
+            if isinstance(header, dict):
+                meta['headers'][kk] = header.copy()
+            else:
+                try:
+                    meta['headers'][kk] = header.tostring()
+                except AttributeError:
+                    if not isinstance(header, basestring):
+                        raise ValueError("Bad format in header")
+                    meta['headers'][kk] = header
     # Clean up the dict
     d = liu.jsonify(meta)
     return json.dumps(d)


### PR DESCRIPTION
Allows for using dict objects instead of Header objects
in XSpectrum1D meta.

Should probably add a test..