### PR TITLE
AbsComponent H2

### DIFF
--- a/linetools/isgm/abscomponent.py
+++ b/linetools/isgm/abscomponent.py
@@ -198,7 +198,7 @@ class AbsComponent(object):
                 except:
                     raise IOError("Need to provide 'stars' parameter.")
             self.name = '{:s}_z{:0.5f}'.format(iname, self.zcomp)
-        elif (self.Zion != (-1, -1)):
+        elif (name is None) and (self.Zion == (-1, -1)):
             self.name = 'mol_z{:0.5f}'.format(self.zcomp)
         else:
             self.name = name

--- a/linetools/isgm/abscomponent.py
+++ b/linetools/isgm/abscomponent.py
@@ -190,7 +190,7 @@ class AbsComponent(object):
             self.sig_logN = 0.
 
         # Name
-        if name is None:
+        if (name is None) and (self.Zion != (-1, -1)):
             iname = ions.ion_name(self.Zion, nspace=0)
             if self.Ej.value > 0:  # Need to put *'s in name
                 try:
@@ -198,6 +198,8 @@ class AbsComponent(object):
                 except:
                     raise IOError("Need to provide 'stars' parameter.")
             self.name = '{:s}_z{:0.5f}'.format(iname, self.zcomp)
+        elif (self.Zion != (-1, -1)):
+            self.name = 'mol_z{:0.5f}'.format(self.zcomp)
         else:
             self.name = name
 
@@ -306,7 +308,7 @@ class AbsComponent(object):
         # get the transitions from LineList
         llist = LineList(llist)
         if (self.Zion) == (-1, -1):
-            # use wrest in the meantime
+            # use wrest in the meantime (this is a patch)
             wrest = self.attrib['init_wrest']
             transitions = llist.all_transitions(wrest)
         else:

--- a/linetools/isgm/abscomponent.py
+++ b/linetools/isgm/abscomponent.py
@@ -43,6 +43,8 @@ class AbsComponent(object):
     Zion : tuple 
         Atomic number, ion -- (int,int)
         e.g. (8,1) for OI
+        Note: (-1, -1) is special and is meant for molecules (e.g. H2)
+              This notation will most likely be changed in the future.
     zcomp : float
         Component redshift
     vlim : Quantity array
@@ -147,6 +149,8 @@ class AbsComponent(object):
         Zion : tuple
             Atomic number, ion -- (int,int)
             e.g. (8,1) for OI
+            Note: (-1, -1) is special and is meant for moleculer (e.g. H2)
+                  This notation will most likely change in the future.
         zcomp : float
             Absorption component redshift
         vlim : Quantity array
@@ -311,7 +315,7 @@ class AbsComponent(object):
         llist = LineList(llist)
         if init_name is None:  # we have to guess it
             if (self.Zion) == (-1, -1):  # molecules
-                # use wrest in the meantime (this is a patch)
+                # init_name must be in self.attrib (this is a patch)
                 init_name = self.attrib['init_name']
             else:  # atoms
                 init_name = ions.ion_name(self.Zion, nspace=0)

--- a/linetools/isgm/tests/test_use_abscomp.py
+++ b/linetools/isgm/tests/test_use_abscomp.py
@@ -221,7 +221,7 @@ def test_iontable_from_components():
     assert len(tbl) == 2
 
 
-def test_complist_from_table():
+def test_complist_from_table_and_table_from_complist():
     tab = QTable()
     tab['ion_name'] = ['HI', 'HI', 'CIV', 'SiII', 'OVI']
     tab['z_comp'] = [0.05, 0.0999, 0.1, 0.1001, 0.6]
@@ -231,25 +231,36 @@ def test_complist_from_table():
     tab['vmax'] = [100.] *len(tab) * u.km / u.s
     complist = ltiu.complist_from_table(tab)
     assert np.sum(complist[0].vlim == [ -50., 100.] * u.km / u.s) == 2
+    tab2 = ltiu.table_from_complist(complist)
+    np.testing.assert_allclose(tab['z_comp'], tab2['z_comp'])
+
     # test other columns
     tab['logN'] = 13.7
     tab['sig_logN'] = 0.1
     tab['flag_logN'] = 1
     complist = ltiu.complist_from_table(tab)
+    tab2 = ltiu.table_from_complist(complist)
+    np.testing.assert_allclose(tab['logN'], tab2['logN'])
+
     comp = complist[0]
     # comment now
     tab['comment'] = ['good', 'good', 'bad', 'bad', 'This is a longer comment with symbols &*^%$']
     complist = ltiu.complist_from_table(tab)
+    tab2 = ltiu.table_from_complist(complist)
     comp = complist[-1]
     assert comp.comment == 'This is a longer comment with symbols &*^%$'
+    assert tab2['comment'][-1] == comp.comment
+
     # other naming
     tab['name'] = tab['ion_name']
     complist = ltiu.complist_from_table(tab)
+    tab2 = ltiu.table_from_complist(complist)
     comp = complist[-1]
     assert comp.name == 'OVI'
     # other attributes
     tab['b'] = [10, 10, 20, 10, 60] * u.km / u.s
     complist = ltiu.complist_from_table(tab)
+    tab2 = ltiu.table_from_complist(complist)
     comp = complist[-1]
     assert comp.attrib['b'] == 60*u.km/u.s
 

--- a/linetools/isgm/tests/test_use_abscomp.py
+++ b/linetools/isgm/tests/test_use_abscomp.py
@@ -19,6 +19,7 @@ from linetools.spectralline import AbsLine
 from linetools.spectra import io as lsio
 from linetools.analysis import absline as ltaa
 from linetools.isgm import utils as ltiu
+# from linetools.lists.linelist import LineList
 import linetools.utils as ltu
 
 import imp, os
@@ -62,6 +63,7 @@ def mk_comp(ctype,vlim=[-300.,300]*u.km/u.s,add_spec=False, use_rand=True,
     abscomp = AbsComponent.from_abslines(abslines)
     return abscomp, abslines
 
+
 def mk_comptable():
     tab = QTable()
     tab['ion_name'] = ['HI', 'HI', 'CIV', 'SiII', 'OVI']
@@ -71,6 +73,7 @@ def mk_comptable():
     tab['vmin'] = [-50.] * len(tab) * u.km/u.s
     tab['vmax'] = [100.] * len(tab) * u.km/u.s
     return tab
+
 
 def data_path(filename):
     data_dir = os.path.join(os.path.dirname(__file__), 'files')
@@ -164,6 +167,7 @@ def test_synthesize_colm():
         abscomp3._abslines[0].attrib['N'] = 0 / u.cm / u.cm
         abscomp3.synthesize_colm(overwrite=True)
 
+
 def test_build_components_from_lines():
     # Lines
     abscomp,HIlines = mk_comp('HI')
@@ -171,6 +175,18 @@ def test_build_components_from_lines():
     # Components
     comps = ltiu.build_components_from_abslines([HIlines[0],HIlines[1],SiIIlines[0],SiIIlines[1]])
     assert len(comps) == 2
+
+
+def test_abscomp_H2():
+    Zion = (-1, -1)  # temporary code for molecules
+    Ntuple = (1, 17, -1)  # initial guess for Ntuple (needs to be given for adding lines from linelist)
+    coord = SkyCoord(0,0, unit='deg')
+    z = 0.212
+    vlim = [-100., 100.] * u.km/u.s
+    comp = AbsComponent(coord, Zion, z, vlim, Ntup=Ntuple)
+    comp.add_abslines_from_linelist(llist='H2', init_name="B19-0P(1)", wvlim=[1100, 5000]*u.AA)
+    assert len(comp._abslines) == 7
+
 
 def test_add_abslines_from_linelist():
     comp, HIlines = mk_comp('HI')
@@ -203,6 +219,7 @@ def test_iontable_from_components():
     comps = ltiu.build_components_from_abslines([HIlines[0],HIlines[1],SiIIlines[0],SiIIlines[1]])
     tbl = ltiu.iontable_from_components(comps)
     assert len(tbl) == 2
+
 
 def test_complist_from_table():
     tab = QTable()
@@ -245,7 +262,6 @@ def test_complist_from_table():
     tab['z_comp'] = [0.05, 0.0999, 0.1, 0.1001, 0.6]
     with pytest.raises(IOError):
         complist = ltiu.complist_from_table(tab) # not enough mandatory columns
-
 
 
 def test_get_components_at_z():

--- a/linetools/isgm/tests/test_use_abscomp.py
+++ b/linetools/isgm/tests/test_use_abscomp.py
@@ -65,7 +65,7 @@ def mk_comp(ctype,vlim=[-300.,300]*u.km/u.s,add_spec=False, use_rand=True,
 
 
 def mk_comptable():
-    tab = QTable()
+    tab = Table()
     tab['ion_name'] = ['HI', 'HI', 'CIV', 'SiII', 'OVI']
     tab['z_comp'] = [0.05, 0.0999, 0.1, 0.1001, 0.6]
     tab['RA'] = [100.0] * len(tab) * u.deg
@@ -222,7 +222,7 @@ def test_iontable_from_components():
 
 
 def test_complist_from_table_and_table_from_complist():
-    tab = QTable()
+    tab = Table()
     tab['ion_name'] = ['HI', 'HI', 'CIV', 'SiII', 'OVI']
     tab['z_comp'] = [0.05, 0.0999, 0.1, 0.1001, 0.6]
     tab['RA'] = [100.0]*len(tab) * u.deg

--- a/linetools/isgm/utils.py
+++ b/linetools/isgm/utils.py
@@ -245,11 +245,11 @@ def xhtbl_from_components(components, ztbl=None, NHI_obj=None):
 
 def complist_from_table(table):
     """
-    Returns a list of AbsComponents from an input Table.
+    Returns a list of AbsComponents from an input astropy.Table.
 
     Parameters
     ----------
-    table : QTable
+    table : Table
         Table with component information (each row must correspond
         to a component). Each column is expecting a unit when
         appropriate.
@@ -274,6 +274,9 @@ def complist_from_table(table):
         with their respective units if given.
 
     """
+    # Convert to QTable to handle units in individual entries more easily
+    table = QTable(table)
+
     # mandatory and optional columns
     min_columns = ['RA', 'DEC', 'ion_name', 'z_comp', 'vmin', 'vmax']
     special_columns = ['name', 'comment', 'logN', 'sig_logN', 'flag_logN']
@@ -328,19 +331,19 @@ def complist_from_table(table):
 
 def table_from_complist(complist):
     """
-    Returns a QTable from an input list of AbsComponents. It only
+    Returns a astropy.Table from an input list of AbsComponents. It only
     fills in mandatory and special attributes (see notes below).
     Information stored in dictionary AbsComp.attrib is ignored.
 
     Parameters
     ----------
-    complist : list of AbsCOmponents
+    complist : list of AbsComponents
         The initial list of AbsComponents to create the QTable from.
 
     Returns
     -------
-    table : QTable
-        QTable from the information contained in each component.
+    table : Table
+        Table from the information contained in each component.
 
     Notes
     -----
@@ -348,7 +351,7 @@ def table_from_complist(complist):
     Special columns: 'name', 'comment', 'logN', 'sig_logN', 'flag_logN'
     See also complist_from_table()
     """
-    tab = QTable()
+    tab = Table()
 
     # mandatory columns
     tab['RA'] = [comp.coord.ra.value for comp in complist] * comp.coord.ra.unit
@@ -512,9 +515,9 @@ def synthesize_components(components, zcomp=None, vbuff=0*u.km/u.s):
 
 
 def get_components_at_z(complist, z, dvlims):
-    """In a given list of components, it finds
+    """In a given list of AbsComponents, it finds
     the ones that are within dvlims from a given redshift
-    and returns a list of those components
+    and returns a list of those.
 
     Parameters
     ----------
@@ -529,7 +532,7 @@ def get_components_at_z(complist, z, dvlims):
     Returns
     -------
     components_at_z : list
-        List of components within complist within dvlims from z
+        List of AbsComponents in complist within dvlims from z
     """
     # check input
     if not isinstance(complist[0], AbsComponent):

--- a/linetools/isgm/utils.py
+++ b/linetools/isgm/utils.py
@@ -354,8 +354,8 @@ def table_from_complist(complist):
     tab = Table()
 
     # mandatory columns
-    tab['RA'] = [comp.coord.ra.value for comp in complist] * comp.coord.ra.unit
-    tab['DEC'] = [comp.coord.dec.value for comp in complist] * comp.coord.dec.unit
+    tab['RA'] = [comp.coord.ra.to('deg').value for comp in complist] * u.deg
+    tab['DEC'] = [comp.coord.dec.to('deg').value for comp in complist] * u.deg
     ion_names = []  # ion_names
     for comp in complist:
         if comp.Zion == (-1,-1):

--- a/linetools/isgm/utils.py
+++ b/linetools/isgm/utils.py
@@ -184,6 +184,7 @@ def build_systems_from_components(comps, systype=None, vsys=None, **kwargs):
     Parameters
     ----------
     comps : list
+        List of AbsComponents
     systype : AbsSystem, optional
       Defaults to GenericAbsSystem
     vsys : Quantity, optional

--- a/linetools/lists/parse.py
+++ b/linetools/lists/parse.py
@@ -153,6 +153,7 @@ def read_H2():
 
     # Units
     data['wrest'].unit = u.AA
+    data['gamma'].unit = 1./u.s
 
     # Rename some columns
     data.rename_column('Jp', 'Jj')


### PR DESCRIPTION
A patch for AbsComponents to work (at a basic level without checks) with H2 lines. This PR is only  meant to make pyigm's IGMguesses to be able to handle H2 molecules. A more fundamental solution is beyond the scope of this PR.