### PR TITLE
Collate in XSpectrum1D

### DIFF
--- a/docs/xspec_multi.rst
+++ b/docs/xspec_multi.rst
@@ -18,8 +18,12 @@ Generation
 ==========
 
 There are currently two ways to generate a multi-spectrum
-`~linetools.spectra.xspectrum1d.XSpectrum1D` object.  The
-first is to feed it a set of np.arrays each with dimension
+`~linetools.spectra.xspectrum1d.XSpectrum1D` object.
+
+Instantiation
+-------------
+
+The first is to feed it a set of np.arrays each with dimension
 (nspec,npix).::
 
     nspec, npix = 3, 100
@@ -29,12 +33,22 @@ first is to feed it a set of np.arrays each with dimension
     #
     mspec = XSpectrum1D(wave, flux, sig)
 
+Collate
+-------
+
 Alternatively, one can generate from a list of
-`~linetools.spectra.xspectrum1d.XSpectrum1D` objects.::
+`~linetools.spectra.xspectrum1d.XSpectrum1D` objects
+using the collate() method.::
 
     from linetools.spectra import utils as ltsu
     mspec = ltsu.collate([spec1,spec2])
 
+If any of the input `~linetools.spectra.xspectrum1d.XSpectrum1D` objects
+are already multi-dimensional, these will all be ingested.
+
+Note: if any of the input objects has a continuum, the resultant
+object will provide a continuum for all with default value=0.
+These 0. values are ignored even if the spectrum is later normalized.
 
 Slice
 =====

--- a/docs/xspectrum1d.rst
+++ b/docs/xspectrum1d.rst
@@ -9,14 +9,19 @@ XSpectrum1D Class
 Overview
 ========
 
-`~linetools.spectra.xspectrum1d.XSpectrum1D` describes a 1-d spectrum,
+`~linetools.spectra.xspectrum1d.XSpectrum1D` contains and
+manipulates 1-d spectra, each of
 which usually consists of a wavelength, flux and flux uncertainty
 array.  For absorption-line analysis, it also often contains a
-continuum array.  The data are held in a masked numpy array which
-may contain multiple spectra.  By default pixels on the edges of the
-spectrum with an input error array having values <=0 are masked.
-It is important to appreciate this masking.  It does mean that
-you will not view, print, analyze, etc. pixels that have been masked.
+continuum array.
+
+The data are held in a masked numpy array which
+may contain multiple spectra.
+By default pixels on the edges of the
+spectrum with an input error array having values <=0 are masked
+at instantiation. It is important to appreciate this masking.
+It does mean that you will not view, print, analyze, etc. pixels
+that have been masked.
 
 Attributes
 ==========
@@ -45,8 +50,8 @@ for flux. The 1-sigma uncertainty is always assumed to have the
 same units as the flux. All of these are specified in the sp.units dict.
 
 If one loads multiple 1D spectra (e.g. a brick of data from DESI
-or a set of spectrum from
-`igmspec <https://github.com/pyigm/igmspec>`_),
+or a set of spectra from
+`specdb <https://github.com/specdb/specdb>`_),
 the selected spectrum is given by the spec.select index.
 
 All of the values are stored in the masked spec.data numpy array
@@ -83,7 +88,7 @@ which contains the wave, flux, sig, etc. values.  This
 is a masked array which is convenient for many applications.
 If you wish to view/analyze all pixels in your spectrum including
 those with 0 or NAN sig values, then disable the mask when
-creating the object or by using the unnmask() method::
+creating the object (masking='None') or by using the unnmask() method::
 
     sp = XSpectrum1D.from_tuple((wa, fl, sig), masking='none')
     sp = XSpectrum1D.from_file('PH957_f.fits')

--- a/linetools/spectra/tests/test_xspec_utils.py
+++ b/linetools/spectra/tests/test_xspec_utils.py
@@ -50,6 +50,10 @@ def test_collate(spec,spec2):
     coll_spec = ltsu.collate([spec,spec2])
     assert coll_spec.nspec == 2
     assert coll_spec.totpix == 20379
+    # Now a 2 and a 1
+    coll_spec2 = ltsu.collate([coll_spec,spec2])
+    assert coll_spec2.nspec == 3
+    assert coll_spec2.totpix == 20379
 
 
 def test_airtovac_andback(spec):

--- a/linetools/spectra/utils.py
+++ b/linetools/spectra/utils.py
@@ -131,9 +131,11 @@ def collate(spectra):
     # Init
     maxpix = 0
     flg_co, flg_sig = False, False
-    nspec = len(spectra)
+    nspec = 0
     units = None
+    # Setup
     for spec in spectra:
+        nspec += spec.nspec
         maxpix = max(maxpix, spec.npix)
         if spec.co_is_set:
             flg_co = True
@@ -152,20 +154,25 @@ def collate(spectra):
     else:
         sig = None
     if flg_co:
-        co = np.zeros_like(wave)
+        co = np.zeros_like(flux)
     else:
         co = None
     # Load
     meta = dict(headers=[])
-    for ii, spec in enumerate(spectra):
-        wave[ii,:spec.npix] = spec.wavelength.value
-        flux[ii,:spec.npix] = spec.flux.value
-        if flg_sig:
-            sig[ii,:spec.npix] = spec.sig.value
-        if flg_co:
-            co[ii,:spec.npix] = spec.co.value
+    idx = 0
+    for xspec in spectra:
+        # Allow for multiple spectra in the XSpectrum1D object
+        for jj in range(xspec.nspec):
+            xspec.select = jj
+            wave[idx,:xspec.npix] = xspec.wavelength.value
+            flux[idx,:xspec.npix] = xspec.flux.value
+            if flg_sig:
+                sig[idx,:xspec.npix] = xspec.sig.value
+            if flg_co:
+                co[idx,:xspec.npix] = xspec.co.value
+            idx += 1
         # Meta
-        meta['headers'].append(spec.header)
+        meta['headers'].append(xspec.header)
     # Finish
     new_spec = XSpectrum1D(wave, flux, sig=sig, co=co, units=units.copy(),
                            masking='edges', meta=meta)

--- a/linetools/spectra/utils.py
+++ b/linetools/spectra/utils.py
@@ -166,10 +166,7 @@ def collate(spectra):
         # Allow for multiple spectra in the XSpectrum1D object
         for jj in range(xspec.nspec):
             xspec.select = jj
-            try:
-                wave[idx,:xspec.npix] = xspec.wavelength.value
-            except ValueError:
-                pdb.set_trace()
+            wave[idx,:xspec.npix] = xspec.wavelength.value
             flux[idx,:xspec.npix] = xspec.flux.value
             if flg_sig:
                 sig[idx,:xspec.npix] = xspec.sig.value

--- a/linetools/spectra/utils.py
+++ b/linetools/spectra/utils.py
@@ -136,7 +136,9 @@ def collate(spectra):
     # Setup
     for spec in spectra:
         nspec += spec.nspec
-        maxpix = max(maxpix, spec.npix)
+        for ii in range(spec.nspec):
+            spec.select = ii
+            maxpix = max(maxpix, spec.npix)
         if spec.co_is_set:
             flg_co = True
         if spec.sig_is_set:
@@ -164,12 +166,16 @@ def collate(spectra):
         # Allow for multiple spectra in the XSpectrum1D object
         for jj in range(xspec.nspec):
             xspec.select = jj
-            wave[idx,:xspec.npix] = xspec.wavelength.value
+            try:
+                wave[idx,:xspec.npix] = xspec.wavelength.value
+            except ValueError:
+                pdb.set_trace()
             flux[idx,:xspec.npix] = xspec.flux.value
             if flg_sig:
                 sig[idx,:xspec.npix] = xspec.sig.value
             if flg_co:
-                co[idx,:xspec.npix] = xspec.co.value
+                if xspec.co_is_set:  # Allow for a mix of continua (mainly for specdb)
+                    co[idx,:xspec.npix] = xspec.co.value
             idx += 1
         # Meta
         meta['headers'].append(xspec.header)

--- a/linetools/utils.py
+++ b/linetools/utils.py
@@ -94,7 +94,7 @@ def radec_to_coord(radec):
 
     Parameters
     ----------
-    radec : str or tuple
+    radec : str or tuple or SkyCoord
         Examples:
         'J124511+144523',
         '124511+144523',
@@ -102,10 +102,12 @@ def radec_to_coord(radec):
         ('12:45:11','+14:45:23')
         ('12 45 11', +14 45 23)
         ('12:45:11','14:45:23')  -- Assumes positive DEC
+        (123.123, 12.1224) -- Assumed deg
 
     Returns
     -------
     coord : SkyCoord
+      Converts to astropy.coordinate.SkyCoord (as needed)
 
     """
     from astropy.coordinates import SkyCoord


### PR DESCRIPTION
Updates collate() method.  Allows for multiple spectra
in each input XSpectrum1D object.

Updates tests and docs