### PR TITLE
laa: added N_from_Wr() and N_from_Wr_transition() with tests.

### DIFF
--- a/docs/absline.rst
+++ b/docs/absline.rst
@@ -61,6 +61,48 @@ Plots
 Methods
 =======
 
+get_Wr_from_N_b
+---------------
+It returns the rest-frame equivalent width for a given `N` and `b`. It uses the approximation given
+by Draine 2011 book (eq. 9.27), which comes from atomic physics considerations.::
+
+    abslin1 = AbsLine('HI 1215')
+    N = [10**12.0, 10**12.1, 10**12.2, 10**14.0] / (u.cm*u.cm)
+    b = [20, 20, 20, 20] * u.km / u.s
+    Wr = abslin1.get_Wr_from_N_b(N, b)
+    print(Wr)
+    <Quantity [ 0.0053758 , 0.00674464, 0.00845469, 0.21149773] Angstrom>
+
+get_Wr_from_N
+---------------
+It returns the approximated rest-frame equivalent width for
+a given N. It uses the approximation given by Draine 2011 book
+(eq. 9.15), which is valid for tau0<<1 where Wr is independent
+of Doppler parameter or gamma.::
+
+    abslin1 = AbsLine('HI 1215')
+    N = [10**12.0, 10**12.1, 10**12.2, 10**14.0] / (u.cm*u.cm)
+    Wr = abslin1.get_Wr_from_N(N)
+    print(Wr)
+    <Quantity [ 0.00544783, 0.00685842, 0.00863423, 0.5447833 ] Angstrom>
+
+We can see how the first 4 `Wr` estimations are good approximation to the more exact solution given by
+get_Wr_from_N_b(), however, the fourth is off by a factor `>2` because the approximation tau0<<1 is not satisfied.
+
+get_N_from_Wr
+-------------
+It returns the approximated column density N, for a given rest-frame equivalent width
+Wr. This is an approximation only valid for tau0 << 1, where
+Wr is independent on Doppler parameter and gamma (see eqs. 9.14 and 9.15 of
+Draine 2011). This may be useful to put upper limits on non-detections.::
+
+    abslin1 = AbsLine('HI 1215')
+    Wr = [ 0.00544783, 0.00685842, 0.00863423, 0.5447833 ] * u.AA
+    N = abslin1.get_N_from_Wr(Wr)
+    print(np.log10(N.value))
+    array([ 11.99999976,  12.10000029,  12.19999983,  14.        ])
+
+
 generate_voigt
 --------------
 

--- a/linetools/analysis/tests/test_absline.py
+++ b/linetools/analysis/tests/test_absline.py
@@ -6,7 +6,9 @@ import pdb
 from astropy import units as u
 
 from linetools.analysis.absline import aodm, log_clm, linear_clm, photo_cross,\
-    sum_logN, get_tau0, Wr_from_N_b, Wr_from_N_b_transition, Wr_from_N, Wr_from_N_transition
+    sum_logN, get_tau0, Wr_from_N_b, Wr_from_N_b_transition, Wr_from_N, Wr_from_N_transition,\
+    N_from_Wr, N_from_Wr_transition
+
 from linetools.lists.linelist import LineList
 
 def test_aodm():
@@ -103,7 +105,7 @@ def test_Wr_from_N_b():
     np.testing.assert_allclose(Wr, Wr_test[0], rtol=1e-5)
 
 
-def test_Wr_from_N():
+def test_Wr_from_N_and_N_from_Wr():
     hi_list = LineList('HI')
     lya = hi_list['HI 1215']
     N = 10**np.linspace(12.0, 12.3, 4) / (u.cm*u.cm)
@@ -111,6 +113,8 @@ def test_Wr_from_N():
     Wr = Wr_from_N(N, lya['wrest'], lya['f'])
     Wr_test = [ 0.00544783, 0.00685842, 0.00863423, 0.01086986] * u.AA
     np.testing.assert_allclose(Wr, Wr_test, rtol=1e-5)
+    N_new = N_from_Wr(Wr, lya['wrest'], lya['f'])
+    np.testing.assert_allclose(N_new, N, rtol=1e-5)
 
 
 def test_Wr_from_N_b_transition():
@@ -128,12 +132,18 @@ def test_Wr_from_N_b_transition():
         Wr = Wr_from_N_b_transition(N[0], b[0], transition='Wrong name jojo')
 
 
-def test_Wr_from_N_transition():
+def test_Wr_from_N_transition_and_viceversa():
     N = 10**np.linspace(12.0, 12.3, 4) / (u.cm*u.cm)
     # test array like
     Wr = Wr_from_N_transition(N, 'HI 1215')
     Wr_test = [ 0.00544783, 0.00685842, 0.00863423, 0.01086986] * u.AA
     np.testing.assert_allclose(Wr, Wr_test, rtol=1e-5)
+    N_new = N_from_Wr_transition(Wr, 'HI 1215')
+    np.testing.assert_allclose(N_new, N, rtol=1e-5)
+
     # test expected error
     with pytest.raises(ValueError):
         Wr = Wr_from_N_transition(N[0], transition='Wrong name jojo')
+    with pytest.raises(ValueError):
+        Wr = N_from_Wr_transition(Wr[0], transition='Wrong name jojo')
+

--- a/linetools/spectralline.py
+++ b/linetools/spectralline.py
@@ -746,6 +746,31 @@ class AbsLine(SpectralLine):
             raise NotImplementedError('AbsLine {} has not set its oscillator strength.'.format(self.__repr__))
         return laa.Wr_from_N(N, self.wrest, fosc)
 
+    def get_N_from_Wr(self, Wr):
+        """It returns the approximated column density N, for a given rest-frame equivalent width
+        Wr. This is an approximation only valid for tau0 << 1, where
+        Wr is independent on Doppler parameter and gamma (see eqs. 9.14 and 9.15 of
+        Draine 2011). This may be useful to put upper limits on non-detections.
+
+        Parameters
+        ----------
+        Wr : Quantity or Quantity array
+            Rest-frame equivalent width of the AbsLine
+
+        Returns
+        -------
+        N : Quantity
+            Approximated column density N valid for the tau0<<1 regime.
+
+        Notes
+        -----
+        This is a wrapper to linetools.analysis.absline.Wr_from_N(). See also self.get_Wr_from_N()
+        """
+        try:
+            fosc = self.data['f']
+        except KeyError:
+            raise NotImplementedError('AbsLine {} has not set its oscillator strength.'.format(self.__repr__))
+        return laa.N_from_Wr(Wr, self.wrest, fosc)
 
     def __repr__(self):
         txt = '<{:s}:'.format(self.__class__.__name__)

--- a/linetools/tests/test_absline_anly.py
+++ b/linetools/tests/test_absline_anly.py
@@ -123,10 +123,12 @@ def test_get_Wr_from_N_b():
     Wr = abslin1.get_Wr_from_N_b(N, b)
 
 
-def test_get_Wr_from_N():
+def test_get_Wr_from_N_and_viceversa():
     abslin1 = AbsLine('HI 1215')
     N = [10**12.0, 10**12.1, 10**12.2] / (u.cm*u.cm)
     Wr = abslin1.get_Wr_from_N(N)
+    N_new = abslin1.get_N_from_Wr(Wr)
+    np.testing.assert_allclose(N, N_new, rtol=1e-5)
 
 
 def test_repr():


### PR DESCRIPTION
N_from_Wr() and N_from_Wr_transition() added to linetools.analysis.absline; these are useful for getting upper limits on N from measured Wr upper limits. Assume tau0<<1 where the relation between N and Wr is independent on Doppler parameter and gamma.