### PR TITLE
Enable list for RA/DEC input

### DIFF
--- a/linetools/tests/test_utils.py
+++ b/linetools/tests/test_utils.py
@@ -104,12 +104,16 @@ def test_save_load_json():
 
 
 def test_radeccoord():
-    for radec in ['J124511+144523', '124511+144523',
+    lcoord = ['J124511+144523', '124511+144523',
                   'J12:45:11+14:45:23', ('12:45:11', '+14:45:23'),
-                  ('12:45:11', '14:45:23'), ('12 45 11', '+14 45 23')]:
+                  ('12:45:11', '14:45:23'), ('12 45 11', '+14 45 23')]
+    for radec in lcoord:
         coord = ltu.radec_to_coord(radec)
         # Test
         np.testing.assert_allclose(coord.ra.value, 191.2958333333333)
+    # List
+    coords = ltu.radec_to_coord(lcoord)
+    assert len(coords) == 6
 
 
 def test_overlapping_chunks():

--- a/linetools/utils.py
+++ b/linetools/utils.py
@@ -94,7 +94,7 @@ def radec_to_coord(radec):
 
     Parameters
     ----------
-    radec : str or tuple or SkyCoord
+    radec : str or tuple or SkyCoord or list
         Examples:
         'J124511+144523',
         '124511+144523',
@@ -103,11 +103,14 @@ def radec_to_coord(radec):
         ('12 45 11', +14 45 23)
         ('12:45:11','14:45:23')  -- Assumes positive DEC
         (123.123, 12.1224) -- Assumed deg
+        [(123.123, 12.1224), (125.123, 32.1224)]
 
     Returns
     -------
     coord : SkyCoord
       Converts to astropy.coordinate.SkyCoord (as needed)
+      Returns a SkyCoord array if input is a list
+
 
     """
     from astropy.coordinates import SkyCoord
@@ -143,6 +146,16 @@ def radec_to_coord(radec):
                 raise ValueError("radec must include + or - for DEC")
             newradec = (radec[0:2]+':'+radec[2:4]+':'+radec[4:sign+3] +':'+radec[sign+3:sign+5]+':'+radec[sign+5:])
             coord = SkyCoord(newradec, frame='fk5', unit=(u.hourangle, u.deg))
+    elif isinstance(radec,list):
+        clist = []
+        for item in radec:
+            clist.append(radec_to_coord(item))
+        # Convert to SkyCoord array
+        ras = [ii.fk5.ra.value for ii in clist]
+        decs = [ii.fk5.dec.value for ii in clist]
+        return SkyCoord(ra=ras, dec=decs, unit='deg')
+    else:
+        raise IOError("Bad input type for radec")
     # Return
     return coord
 


### PR DESCRIPTION
As titled.

Solely for the radec_to_coord() method.

No new docs.