### PR TITLE
Refactor linelists from QTable -> Table

### DIFF
--- a/linetools/guis/line_widgets.py
+++ b/linetools/guis/line_widgets.py
@@ -282,7 +282,7 @@ class SelectedLinesWidget(QWidget):
         nlin = len(self.lines['wrest'])
         for ii in range(nlin):
             self.lines_widget.addItem('{:s} :: {:.3f} :: {}'.format(self.lines['name'][ii],
-                                                         self.lines['wrest'][ii].value,
+                                                         self.lines['wrest'][ii],
                                                          self.lines['f'][ii]))
 
     def on_item_change(self): #,item):

--- a/linetools/guis/spec_widgets.py
+++ b/linetools/guis/spec_widgets.py
@@ -582,7 +582,7 @@ class ExamineSpecWidget(QWidget):
                                  (wvobs < self.psdict['x_minmax'][1]))[0]
                 for kk in range(len(gdwv)):
                     jj = gdwv[kk]
-                    wrest = self.llist[self.llist['List']].wrest[jj].value
+                    wrest = self.llist[self.llist['List']].wrest[jj]
                     lbl = self.llist[self.llist['List']].name[jj]
                     # Plot
                     self.ax.plot(wrest*np.array([z+1,z+1]), self.psdict['y_minmax'], 'b--')
@@ -777,6 +777,10 @@ U         : Indicate as a upper limit
         #
         wrest = self.llist[self.llist['List']].wrest
         wvobs = (1+self.z) * wrest
+
+        #QtCore.pyqtRemoveInputHook()
+        #pdb.set_trace()
+        #QtCore.pyqtRestoreInputHook()
         gdlin = np.where( (wvobs > wvmin) & (wvobs < wvmax) )[0]
         self.llist['show_line'] = gdlin
 

--- a/linetools/lists/linelist.py
+++ b/linetools/lists/linelist.py
@@ -812,14 +812,14 @@ class LineList(object):
                 aux = self.from_dict_to_table(aux)
 
             # convert to Table because Table does not like vstack
-            output = vstack([output, Table(aux)])
+            output = vstack([output, aux])
 
         # Deal with output formatting now
         # if len==1 return dict
         if len(output) == 1:
             return self.from_table_to_dict(output)
         else:
-            return Table(output)
+            return output
 
     def from_dict_to_table(self, a):
         """Converts dictionary `a` to its Table version.

--- a/linetools/lists/linelist.py
+++ b/linetools/lists/linelist.py
@@ -14,6 +14,7 @@ from astropy import units as u
 from astropy.units.quantity import Quantity
 from astropy.table import Table, vstack, Column, MaskedColumn
 import warnings
+import pdb
 
 import imp
 
@@ -198,7 +199,10 @@ class LineList(object):
                             if mt.sum() == 0:
                                 newi.append(jj)
                         # Append
-                        full_table = vstack([full_table, table[newi]])
+                        try:
+                            full_table = vstack([full_table, table[newi]])
+                        except NotImplementedError:
+                            pdb.set_trace()
                     # Save to avoid repeating
                     all_func.append(func)
 

--- a/linetools/lists/linelist.py
+++ b/linetools/lists/linelist.py
@@ -118,9 +118,9 @@ class LineList(object):
 
     @property
     def wrest(self):
-        """ Return the rest wavelengths
+        """ Return the rest wavelengths as a Quantity array
         """
-        return self._data['wrest']
+        return Quantity(self._data['wrest'])
 
     @property
     def Z(self):

--- a/linetools/lists/mk_sets.py
+++ b/linetools/lists/mk_sets.py
@@ -161,14 +161,14 @@ def add_galaxy_lines(outfil, infil=None, stop=True):
     tmp_row['fgE'] = 1
     # Add if new
     for row in forbidden:
-        if np.sum(np.abs(row['wrest'].value-data['wrest']) < 0.0001) == 0:
-            tmp_row['wrest'] = row['wrest'].value
+        if np.sum(np.abs(row['wrest']-data['wrest']) < 0.0001) == 0:
+            tmp_row['wrest'] = row['wrest']
             tmp_row['name'] = row['name']
             data.add_row(tmp_row)
     # Add if new
     for row in recomb:
-        if np.sum(np.abs(row['wrest'].value-data['wrest']) < 0.0001) == 0:
-            tmp_row['wrest'] = row['wrest'].value
+        if np.sum(np.abs(row['wrest']-data['wrest']) < 0.0001) == 0:
+            tmp_row['wrest'] = row['wrest']
             tmp_row['name'] = row['name'].replace('_',' ')
             data.add_row(tmp_row)
 

--- a/linetools/lists/parse.py
+++ b/linetools/lists/parse.py
@@ -860,7 +860,7 @@ def update_fval(table, verbose=False):
         new_row['name'] = 'AsII 1355'
         new_row['f'].mask = True
         # Stack
-        table = Table(vstack([Table(table), new_row]))
+        table = vstack([table, new_row])
 
     return table
 
@@ -931,7 +931,7 @@ def _write_ref_ISM_table():
     hi = LineList('HI', use_ISM_table=False)
 
     # need a Table to write
-    tab = Table(ism._data.copy())
+    tab = ism._data.copy()
     tab.sort(('wrest'))
 
     # Using np.in1d doesn't work for some reason. Do it the long way

--- a/linetools/lists/tests/test_init_linelist.py
+++ b/linetools/lists/tests/test_init_linelist.py
@@ -17,6 +17,7 @@ from linetools.lists import mk_sets as llmk
 
 def test_ism_read_source_catalogues():
     ism = LineList('ISM', use_ISM_table=False)
+    pytest.set_trace()
     np.testing.assert_allclose(ism['HI 1215']['wrest'],
                                1215.6700*u.AA, rtol=1e-7)
 

--- a/linetools/lists/tests/test_init_linelist.py
+++ b/linetools/lists/tests/test_init_linelist.py
@@ -17,16 +17,13 @@ from linetools.lists import mk_sets as llmk
 
 def test_ism_read_source_catalogues():
     ism = LineList('ISM', use_ISM_table=False)
-    pytest.set_trace()
-    np.testing.assert_allclose(ism['HI 1215']['wrest'],
-                               1215.6700*u.AA, rtol=1e-7)
+    np.testing.assert_allclose(ism['HI 1215']['wrest'], 1215.6700*u.AA, rtol=1e-7)
 
 # ISM LineList
 def test_ism():
     ism = LineList('ISM')
     #
-    np.testing.assert_allclose(ism['HI 1215']['wrest'],
-                               1215.6700*u.AA, rtol=1e-7)
+    np.testing.assert_allclose(ism['HI 1215']['wrest'], 1215.6700*u.AA, rtol=1e-7)
 
 # Test update_fval
 def test_updfval():
@@ -50,7 +47,7 @@ def test_strong():
 def test_euv():
     euv = LineList('EUV')
     #
-    assert np.max(euv._data['wrest'].value) < 1000.
+    assert np.max(euv._data['wrest']) < 1000.
 
 # HI LineList
 def test_h1():
@@ -75,7 +72,7 @@ def test_co():
 def test_galx():
     galx = LineList('Galaxy')
     #
-    np.testing.assert_allclose(galx["Halpha"]['wrest'].value, 6564.613, rtol=1e-5)
+    np.testing.assert_allclose(galx["Halpha"]['wrest'], 6564.613*u.AA, rtol=1e-5)
 
 
 # Unknown lines

--- a/linetools/lists/tests/test_use_linelist.py
+++ b/linetools/lists/tests/test_use_linelist.py
@@ -10,7 +10,7 @@ import os, pdb
 import pytest
 import astropy.io.ascii as ascii
 from astropy import units as u
-from astropy.table import QTable
+from astropy.table import Table
 import numpy as np
 
 from linetools.lists.linelist import LineList
@@ -44,7 +44,7 @@ def test_closest():
     ism.closest=True
     # 
     line = ism[1250.584*u.AA]
-    np.testing.assert_allclose(line['wrest'], 1250.578*u.AA, rtol=1e-7)
+    np.testing.assert_allclose(line['wrest'], 1250.578, rtol=1e-7)
 
 def test_all_transitions():
     error_msg = 'Something is wrong in all_transitions()'
@@ -85,7 +85,7 @@ def test_strongest_transitions():
     transitions = ism.strongest_transitions('HI',wvlims/(1+z),n_max=5)
     assert len(transitions) == 5,  error_msg
     assert transitions[0]['name'] == 'HI 1025' , error_msg
-    assert isinstance(transitions,QTable), error_msg
+    assert isinstance(transitions,Table), error_msg
 
     wvlims = (1500,1700)*u.AA
     z = 0.5
@@ -106,7 +106,7 @@ def test_available_transitions():
 
     transitions = ism.available_transitions(wvlims/(1+z),n_max_tuple=5)
     assert transitions[2]['name'] == 'HI 972' , error_msg
-    assert isinstance(transitions,QTable), error_msg
+    assert isinstance(transitions,Table), error_msg
 
     transitions = ism.available_transitions(wvlims/(1+z),n_max_tuple=2)
     assert transitions[2]['name'] == 'CIII 977' , error_msg

--- a/linetools/lists/tests/test_use_linelist.py
+++ b/linetools/lists/tests/test_use_linelist.py
@@ -23,7 +23,7 @@ def test_lines_from_ion():
     ism = LineList('ISM')
     # 
     lines = ism[(6,2)]
-    assert (1334.5323*u.AA in lines['wrest'])
+    assert (1334.5323 in lines['wrest'])
 
 def test_subset():
     ism = LineList('ISM')
@@ -43,8 +43,8 @@ def test_closest():
     ism = LineList('ISM')
     ism.closest=True
     # 
-    line = ism[1250.584*u.AA]
-    np.testing.assert_allclose(line['wrest'], 1250.578, rtol=1e-7)
+    line = ism[1250.584*u.AA]  # dict with units
+    np.testing.assert_allclose(line['wrest'], 1250.578*u.AA, rtol=1e-7)
 
 def test_all_transitions():
     error_msg = 'Something is wrong in all_transitions()'

--- a/linetools/spectralline.py
+++ b/linetools/spectralline.py
@@ -251,7 +251,7 @@ class SpectralLine(object):
 
 
         # Update
-        self.wrest = self.data['wrest']
+        self.wrest = self.data['wrest']*self.data['wrest'].unit
         self.name = self.data['name']
 
         #

--- a/linetools/spectralline.py
+++ b/linetools/spectralline.py
@@ -251,7 +251,10 @@ class SpectralLine(object):
 
 
         # Update
-        self.wrest = self.data['wrest']*self.data['wrest'].unit
+        if isinstance(self.data, dict):
+            self.wrest = self.data['wrest']
+        else:
+            self.wrest = self.data['wrest']*self.data['wrest'].unit
         self.name = self.data['name']
 
         #


### PR DESCRIPTION
Despite my original fascination with QTable's, I've come
to consider them a greater pain than good.

This PR removes the use of QTable's in linelists in linetools.

tests updated
no doc changes aside from those in the modules

It is possible a Notebook or two will break, but I doubt it.