### PR TITLE
SelectLineWidget. Init self.line attribute as str.

### DIFF
--- a/linetools/guis/line_widgets.py
+++ b/linetools/guis/line_widgets.py
@@ -182,6 +182,7 @@ class SelectLineWidget(QDialog):
         self.lines_widget = QListWidget(self)
         self.lines_widget.addItem('None')
         self.lines_widget.setCurrentRow(0)
+        self.line = "None"  # init "selected line" as "None"
 
         # Loop on lines (could put a preferred list first)
         # Sort


### PR DESCRIPTION
I found that I needed to explicitly initialize `self.line` in `SelectLineWidget` for not breaking IGMGuesses using such widget (see also PR#108 in pyigm).