### PR TITLE
Catch all for GUI key stroke errors

### DIFF
--- a/linetools/analysis/interactive_plot.py
+++ b/linetools/analysis/interactive_plot.py
@@ -86,10 +86,14 @@ S,U          Smooth/unsmooth spectrum
         """
         # Requiring inaxes for all of these now
         if (event.key in self.nav_dict['nav']) and event.inaxes:
-            ltgu.navigate(self.nav_dict, event, flux=self.fl, wave=self.wa)
-            self.ax.set_xlim(self.nav_dict['x_minmax'])
-            self.ax.set_ylim(self.nav_dict['y_minmax'])
-            self.fig.canvas.draw()
+            try:
+                ltgu.navigate(self.nav_dict, event, flux=self.fl, wave=self.wa)
+            except KeyError:
+                pass
+            else:
+                self.ax.set_xlim(self.nav_dict['x_minmax'])
+                self.ax.set_ylim(self.nav_dict['y_minmax'])
+                self.fig.canvas.draw()
 
     def on_keypress_smooth(self, event):
         """ Smooth the flux with a gaussian. Requires attributes

--- a/linetools/analysis/interactive_plot.py
+++ b/linetools/analysis/interactive_plot.py
@@ -538,6 +538,15 @@ q        : quit
                     x not in list(zip(*self.contpoints))[0]):
                 y = local_median(self.wa, self.fl, self.er, x, npix=self.numguesspix,
                                  default=event.ydata)
+            # Check for duplication
+            xpts, ypts = zip(*self.contpoints)
+            xpts = np.array(xpts)
+            xpts[ind] = x
+            uni = np.unique(xpts)
+            if len(self.contpoints) != len(uni):
+                print("Duplicate x value!  Try another spot")
+                return
+            # Finish
             self.contpoints[ind] = x, float(y)
             self.contpoints.sort()
             self.update()

--- a/linetools/guis/spec_widgets.py
+++ b/linetools/guis/spec_widgets.py
@@ -208,7 +208,7 @@ class ExamineSpecWidget(QWidget):
         self.canvas.setFocusPolicy( QtCore.Qt.ClickFocus )
         self.canvas.setFocus()
         if key_events:
-            self.canvas.mpl_connect('key_press_event', self.on_key)
+            self.canvas.mpl_connect('key_press_event', self.on_key_wrapper)
         self.canvas.mpl_connect('button_press_event', self.on_click)
 
         # Make two plots
@@ -251,6 +251,12 @@ class ExamineSpecWidget(QWidget):
         self.psdict['nav'] = ltgu.navigate(0, 0, init=True)
         # Analysis dict
         self.adict['flg'] = 0  # Column density flag
+
+    def on_key_wrapper(self, event):
+        try:
+            self.on_key(event)
+        except:
+            print("That key stroke generated an error!!")
 
     def on_key(self, event):
         """ Deals with key events
@@ -777,7 +783,7 @@ U         : Indicate as a upper limit
 
         self.canvas.setFocusPolicy( QtCore.Qt.ClickFocus )
         self.canvas.setFocus()
-        self.canvas.mpl_connect('key_press_event', self.on_key)
+        self.canvas.mpl_connect('key_press_event', self.on_key_wrapper)
         self.canvas.mpl_connect('button_press_event', self.on_click)
 
         # Sub_plots (Initial)
@@ -870,8 +876,13 @@ U         : Indicate as a upper limit
             _ = self.abs_lines.pop(idx)
 
     # Key stroke
-    def on_key(self,event):
+    def on_key_wrapper(self,event):
+        try:
+            self.on_key(event)
+        except:
+            print("That key stroke raised an error!")
 
+    def on_key(self,event):
         # Init
         rescale = True
         fig_clear = False


### PR DESCRIPTION
A bit aggressive, but a nice way to stop PyQt crashing
on a bad key-stroke entry.

I don't think there is a downside.  We could include key
clicks and also add to pyigm (e.g. igmguesses).