### PR TITLE
Unique components

### DIFF
--- a/linetools/analysis/tests/test_zlimits.py
+++ b/linetools/analysis/tests/test_zlimits.py
@@ -1,4 +1,4 @@
-# Tests of LineLimits class
+# Tests of zLimits class
 from __future__ import print_function, absolute_import, division, unicode_literals
 
 
@@ -7,31 +7,35 @@ import pytest
 
 from astropy import units as u
 
-from linetools.analysis.linelimits import LineLimits
+from linetools.analysis.zlimits import zLimits
 from linetools.spectralline import AbsLine
 
 def test_init():
     # Init
     zlim = (0.999, 1.001)
-    llim = LineLimits(1215.67*u.AA, 1., zlim)
+    llim = zLimits(1., zlim)
+    # Init
+    zlim = (0.999, 1.001)
+    llim = zLimits(1., zlim, wrest=1215.67*u.AA)
     # Test
     with pytest.raises(AttributeError):
         llim.zlim=3
     # AbsLine
     lya = AbsLine('HI 1215')
     z=1.
-    llim = LineLimits.from_specline(lya, z, zlim)
+    zlim = (0.999, 1.001)
+    llim = zLimits.from_specline(lya, z, zlim)
     # Bad zlim
     with pytest.raises(IOError):
-        llim = LineLimits(1215.67*u.AA, 1., (1.1,1.2), chk_z=True)
+        llim = zLimits(1., (1.1,1.2), wrest=1215.67*u.AA, chk_z=True)
     # Null zlim
-    llim = LineLimits(1215.67*u.AA, 1., (1.,1))
+    llim = zLimits(1., (1.,1), wrest=1215.67*u.AA)
     assert llim.is_set() is False
 
 def test_set():
     # Init
     zlim = (0.999, 1.001)
-    llim = LineLimits(1215.67*u.AA, 1., zlim)
+    llim = zLimits(1., zlim, wrest=1215.67*u.AA)
     # Set
     llim.set(zlim)
     np.testing.assert_allclose(llim.wvlim.value, [2430.12433, 2432.55567])
@@ -41,7 +45,7 @@ def test_set():
 
 def test_use():
     # Init
-    llim = LineLimits(1215.67*u.AA, 1., (0.999, 1.001))
+    llim = zLimits(1., (0.999, 1.001), wrest=1215.67*u.AA)
     # Use
     np.testing.assert_allclose(llim.zlim, (0.999, 1.001))
     np.testing.assert_allclose(llim.wvlim.value, [2430.12433, 2432.55567])
@@ -52,7 +56,7 @@ def test_use():
 
 def test_to_dict():
     # Init
-    llim = LineLimits(1215.67*u.AA, 1., (0.999, 1.001))
+    llim = zLimits(1., (0.999, 1.001), wrest=1215.67*u.AA)
     ldict = llim.to_dict()
     for key in ['vlim', 'wrest', 'wvlim', 'z', 'zlim']:
         assert key in ldict.keys()

--- a/linetools/analysis/utils.py
+++ b/linetools/analysis/utils.py
@@ -67,6 +67,9 @@ def gaussian_ew(spec, ltype, initial_guesses=None):
     # Grab
     wv,fx,sig = spec
 
+    if ltype == 'Abs':
+        fx = 1.-fx
+
     # dwv
     dwv = wv - np.roll(wv,1)
     dwv[0] = dwv[1]
@@ -91,13 +94,8 @@ def gaussian_ew(spec, ltype, initial_guesses=None):
         raise ValueError('gaussian_ew: Format of the initial_guesses is incorrect')
 
     # Model initialization
-    if ltype == 'Abs':
-        g_init = models.GaussianAbsorption1D(amplitude=amp_init, mean=mean_init, stddev=stddev_init) # This model does not support units
-    elif ltype == 'Emiss':
-        g_init = models.Gaussian1D(amplitude=amp_init, mean=mean_init, stddev=stddev_init) # This model does not support units
-    else:
-        raise ValueError("gaussian_ew: ltype has to be either 'Abs' or 'Emiss'")    
-    
+    g_init = models.Gaussian1D(amplitude=amp_init, mean=mean_init, stddev=stddev_init) # This model does not support units
+
     # Fitting algorithm initialization
     fit_g = fitting.LevMarLSQFitter()
     # Use only good values (i.e. with meaningful errors)

--- a/linetools/analysis/zlimits.py
+++ b/linetools/analysis/zlimits.py
@@ -16,6 +16,8 @@ ckms = const.c.to('km/s')
 
 class zLimits(object):
     """ An object for handling the 'limits' of a line
+    The input redshift is not meant to be modified (ever).
+    One should re-instantiate instead.
 
     Properties
     ----------

--- a/linetools/analysis/zlimits.py
+++ b/linetools/analysis/zlimits.py
@@ -24,6 +24,7 @@ class zLimits(object):
     zlim : tuple of floats
       Redshift limits for a line
       Defined as wave/wrest - 1.
+      or
     wvlim : Quantity array, only if _wrest is set
       wavelength limits for the line in observer frame
     vlim : Quantity array
@@ -148,7 +149,7 @@ class zLimits(object):
             return False
 
     def set(self, inp, chk_z=False):#, itype='zlim'):
-        """ Over-ride = to re-init values
+        """ Set (or reset) limits relative to self._z
 
         Parameters
         ----------
@@ -173,14 +174,13 @@ class zLimits(object):
         if isinstance(inp[0], float):  # assume zlim
             self._zlim = inp
         elif isinstance(inp[0], Quantity):  # may be wvlim or vlim
-            try:  # assume wvlim
+            if inp[0].cgs.unit == u.cm:
                 self._zlim = (inp/self._wrest).decompose().to(
                         u.dimensionless_unscaled).value - 1.
-            except UnitConversionError:
-                try:  # assume vlim
-                    self._zlim = ltu.z_from_dv(inp, self._z)
-                except ValueError:
-                    raise IOError("Quantity must be length or speed.")
+            elif inp[0].cgs.unit == u.cm/u.s:
+                self._zlim = ltu.z_from_dv(inp, self._z)
+            else:
+                raise IOError("Quantity must be length or speed.")
         else:
             raise IOError("Input must be floats or Quantities.")
         # Check

--- a/linetools/analysis/zlimits.py
+++ b/linetools/analysis/zlimits.py
@@ -23,10 +23,10 @@ class zLimits(object):
       Redshift
     zlim : tuple of floats
       Redshift limits for a line
-      Defined as wave/wrest - 1.
-      or
-    wvlim : Quantity array, only if _wrest is set
+    wvlim : Quantity array, optional
       wavelength limits for the line in observer frame
+      This property exists only if _wrest has been set,
+      e.g. from an AbsLine object
     vlim : Quantity array
       velocity limits for the line
     """
@@ -38,6 +38,10 @@ class zLimits(object):
         Parameters
         ----------
         aline : AbsLine
+        z : float
+          Redshift
+        zlim : tuple of floats
+          Redshift limits for a line
         """
         from ..spectralline import AbsLine, EmLine
         if not isinstance(aline, (AbsLine, EmLine)):
@@ -78,7 +82,8 @@ class zLimits(object):
           Defined as wave/wrest - 1.
           Ok to have zlim[1]==zlim[0], but then self.is_set() == False
         wrest : Quantity, optional
-          Rest wavelength.  Used for SpectralLine objects
+          Rest wavelength.  Frequently used with SpectralLine objects
+          This quantity is used to determine wvlim (from zlim)
         """
         # Error checking
         if not isinstance(z, (float,int)):
@@ -150,6 +155,7 @@ class zLimits(object):
 
     def set(self, inp, chk_z=False):#, itype='zlim'):
         """ Set (or reset) limits relative to self._z
+        but does not change self._z
 
         Parameters
         ----------

--- a/linetools/isgm/abscomponent.py
+++ b/linetools/isgm/abscomponent.py
@@ -25,6 +25,7 @@ from linetools.spectralline import AbsLine, SpectralLine
 from linetools.abund import ions
 from linetools import utils as ltu
 from linetools.lists.linelist import LineList
+from linetools.analysis.linelimits import LineLimits
 
 # Global import for speed
 c_kms = const.c.to('km/s').value
@@ -209,6 +210,7 @@ class AbsComponent(object):
         self.Zion = Zion
         self.zcomp = zcomp
         self.vlim = vlim
+        self.limits = LineLimits(sline.wrest, z, [z,z])
 
         # Optional
         self.A = A

--- a/linetools/isgm/abscomponent.py
+++ b/linetools/isgm/abscomponent.py
@@ -25,7 +25,7 @@ from linetools.spectralline import AbsLine, SpectralLine
 from linetools.abund import ions
 from linetools import utils as ltu
 from linetools.lists.linelist import LineList
-from linetools.analysis.linelimits import LineLimits
+from linetools.analysis.zlimits import zLimits
 
 # Global import for speed
 c_kms = const.c.to('km/s').value
@@ -208,9 +208,9 @@ class AbsComponent(object):
         # Required
         self.coord = ltu.radec_to_coord(radec)
         self.Zion = Zion
-        self.zcomp = zcomp
-        self.vlim = vlim
-        self.limits = LineLimits(sline.wrest, z, [z,z])
+        # Limits
+        zlim = ltu.z_from_dv(vlim, zcomp)
+        self.limits = zLimits(zcomp, zlim.tolist())
 
         # Optional
         self.A = A
@@ -250,6 +250,14 @@ class AbsComponent(object):
 
         # Other
         self._abslines = []
+
+    @property
+    def vlim(self):
+        return self.limits.vlim
+
+    @property
+    def zcomp(self):
+        return self.limits.z
 
     def add_absline(self, absline, tol=0.1*u.arcsec, chk_vel=True,
                     chk_sep=True, vtoler=1., **kwargs):

--- a/linetools/isgm/tests/test_use_abscomp.py
+++ b/linetools/isgm/tests/test_use_abscomp.py
@@ -19,8 +19,6 @@ from linetools.spectralline import AbsLine
 from linetools.spectra import io as lsio
 from linetools.analysis import absline as ltaa
 from linetools.isgm import utils as ltiu
-# from linetools.lists.linelist import LineList
-import linetools.utils as ltu
 
 import imp, os
 lt_path = imp.find_module('linetools')[1]
@@ -90,6 +88,12 @@ def compare_two_files(file1, file2):
     f1.close()
     f2.close()
 
+def test_unique_comps():
+    # One list of components
+    SiIIcomp,_ = mk_comp('SiII',vlim=[-300.,50.]*u.km/u.s)
+    HIcomp,_ = mk_comp('HI')
+    # Run
+    ltiu.unique_components([SiIIcomp], [HIcomp, SiIIcomp])
 
 def test_add_absline():
     abscomp,_ = mk_comp('HI', zcomp=0.)

--- a/linetools/isgm/tests/test_use_abscomp.py
+++ b/linetools/isgm/tests/test_use_abscomp.py
@@ -93,7 +93,8 @@ def test_unique_comps():
     SiIIcomp,_ = mk_comp('SiII',vlim=[-300.,50.]*u.km/u.s)
     HIcomp,_ = mk_comp('HI')
     # Run
-    ltiu.unique_components([SiIIcomp], [HIcomp, SiIIcomp])
+    uniq = ltiu.unique_components([HIcomp, SiIIcomp], [SiIIcomp])
+    assert np.all(uniq == np.array([True,False]))
 
 def test_add_absline():
     abscomp,_ = mk_comp('HI', zcomp=0.)
@@ -235,7 +236,8 @@ def test_complist_from_table_and_table_from_complist():
     tab['vmax'] = [100.] *len(tab) * u.km / u.s
     tab['reliability'] = ['a', 'b', 'b', 'none', 'a']
     complist = ltiu.complist_from_table(tab)
-    assert np.sum(complist[0].vlim == [ -50., 100.] * u.km / u.s) == 2
+    tmp = [-50.,100.]*u.km/u.s
+    assert np.all(np.isclose(complist[0].vlim.value, tmp.value))
     tab2 = ltiu.table_from_complist(complist)
     np.testing.assert_allclose(tab['z_comp'], tab2['z_comp'])
 

--- a/linetools/isgm/tests/utils.py
+++ b/linetools/isgm/tests/utils.py
@@ -50,6 +50,21 @@ def si2_comp(radec):
     #
     return SiII_comp
 
+def oi_comp(radec, vlim=[-250.,80.]*u.km/u.s, z=2.92939):
+    # SiII
+    OItrans = ['OI 1302']
+    abslines = []
+    for trans in OItrans:
+        iline = AbsLine(trans, z=z)
+        iline.attrib['coord'] = radec
+        iline.limits.set(vlim)
+        abslines.append(iline)
+    #
+    OI_comp = AbsComponent.from_abslines(abslines)
+    OI_comp.logN = 15.
+    OI_comp.flag_N = 1
+    #
+    return OI_comp
 
 def make_gensl():
     radec = SkyCoord(ra=123.1143*u.deg, dec=-12.4321*u.deg)

--- a/linetools/isgm/tests/utils.py
+++ b/linetools/isgm/tests/utils.py
@@ -72,15 +72,4 @@ def write_comps_to_sys():
     # Write
     gensl.write_json()
 
-# Command line execution
-if __name__ == '__main__':
-
-    flg_tab = 0
-    flg_tab += 2**0  # Comps to System
-
-    # Generate
-    if flg_tab & (2**0):
-        write_comps_to_sys()
-        # WRites to Foo.json
-
 

--- a/linetools/isgm/utils.py
+++ b/linetools/isgm/utils.py
@@ -891,7 +891,7 @@ def joebvp_from_components(comp_list, specfile, outfile):
 def unique_components(comps1, comps2, tol=5*u.arcsec):
     """ Identify which AbsComponent members of the comps1 list
     are *not* within the comps2 list, to given tolerances.
-    Note, AbsComponent objects in the comps1 list are examined
+    Note, AbsComponent objects in the comps1 list are not examined
     against each other for uniqueness.
 
     Unique if any apply (test is done in this order)

--- a/linetools/isgm/utils.py
+++ b/linetools/isgm/utils.py
@@ -489,7 +489,7 @@ def synthesize_components(components, zcomp=None, vbuff=0*u.km/u.s):
     Requires consistent RA/DEC, Zion, Ej, (A; future)
     Is agnostic about z+vlim
     Melds column densities
-    Melds velocities with a small buffer (10 km/s)
+    Melds velocities with an optional buffer
 
     Note: Could make this a way to instantiate AbsComponent
 
@@ -889,9 +889,10 @@ def joebvp_from_components(comp_list, specfile, outfile):
 
 
 def unique_components(comps1, comps2, tol=5*u.arcsec):
-    """ Identify which members of comps1 are *not* within
-    comps2, to given tolerances.  Note, that repeats in
-    comps1 are not looked for.
+    """ Identify which AbsComponent members of the comps1 list
+    are *not* within the comps2 list, to given tolerances.
+    Note, AbsComponent objects in the comps1 list are examined
+    against each other for uniqueness.
 
     Unique if any apply (test is done in this order)
       1) coord.separation > tol

--- a/linetools/spectralline.py
+++ b/linetools/spectralline.py
@@ -19,7 +19,7 @@ from astropy.coordinates import SkyCoord
 
 from linetools.analysis import utils as lau
 from linetools.analysis import absline as laa
-from linetools.analysis.linelimits import LineLimits
+from linetools.analysis.zlimits import zLimits
 from linetools.lists.linelist import LineList
 from linetools import utils as ltu
 from linetools.spectra.xspectrum1d import XSpectrum1D
@@ -74,7 +74,7 @@ class SpectralLine(object):
         Analysis inputs (e.g. a spectrum, wavelength limits)
     data : dict
         Line atomic/molecular data (e.g. f-value, A coefficient, Elow)
-    limits : LineLimits
+    limits : zLimits
         Limits including zlim, vlim, wvlim.
     """
 
@@ -164,9 +164,9 @@ class SpectralLine(object):
                 # import pdb; pdb.set_trace()
                 idict['limits']['wrest'] = ltu.jsonify(sline.wrest)
                 idict['limits']['z'] = z
-            sline.limits = LineLimits.from_dict(idict['limits'])
+            sline.limits = zLimits.from_dict(idict['limits'])
         else:
-            sline.limits = LineLimits(sline.wrest, z, [z,z])
+            sline.limits = zLimits(z, [z,z], wrest=sline.wrest)
             if 'vlim' in sline.analy.keys():  # Backwards compatability
                 if sline.analy['vlim'][1] > sline.analy['vlim'][0]:
                     sline.limits.set(sline.analy['vlim'])
@@ -197,14 +197,14 @@ class SpectralLine(object):
         self.fill_data(trans, linelist=linelist, closest=closest, verbose=verbose)
         # Redshift Limits
         if z is None:
-            warnings.warn("Redshift not input.  Setting to 0 for LineLimits")
+            warnings.warn("Redshift not input.  Setting to 0 for zLimits")
             z=0.
         try:
             zlim = kwargs['zlim']
         except KeyError:
             zlim = [z,z]
         if ltype in ['Abs', 'Em']:
-            self.limits = LineLimits.from_specline(self, z, zlim)
+            self.limits = zLimits.from_specline(self, z, zlim)
         else:
             raise ValueError('Not ready to set limits for this type')
 


### PR DESCRIPTION
There are two threads to this PR:

- Refactor from LineLimits to zLimits
- Add a unique_components() method

The first allows for limits without reference to wrest.
That becomes optional, so previous functionality is maintained.

The second is a method useful for querying lists of components.

I also removed GaussianAbsorption1D as that is deprecated in astropy.

Includes a new test, but no new docs.