### PR TITLE
A few AbsComponent edits

### DIFF
--- a/linetools/isgm/abscomponent.py
+++ b/linetools/isgm/abscomponent.py
@@ -138,7 +138,7 @@ class AbsComponent(object):
         if coord is not None:
             radec = coord
         else:
-            radec = SkyCoord(ra=idict['RA']*u.deg, dec=idict['DEC']*u.deg)
+            radec = SkyCoord(ra=idict['RA'], dec=idict['DEC'], unit='deg')
         # Init
         #slf = cls(radec, tuple(idict['Zion']), idict['zcomp'], Quantity(idict['vlim'], unit='km/s'),
 
@@ -158,7 +158,7 @@ class AbsComponent(object):
 
         # Add lines
         for key in idict['lines'].keys():
-            iline = SpectralLine.from_dict(idict['lines'][key], coord=coord, **kwargs)
+            iline = AbsLine.from_dict(idict['lines'][key], coord=coord, **kwargs)
             slf.add_absline(iline, **kwargs)
         # Return
         return slf
@@ -215,6 +215,7 @@ class AbsComponent(object):
         # Optional
         self.A = A
         self.Ej = Ej
+        self.stars = stars
         self.comment = comment
         if Ntup is not None:
             self.flag_N = Ntup[0]
@@ -230,10 +231,11 @@ class AbsComponent(object):
         if (name is None) and (self.Zion != (-1, -1)):
             iname = ions.ion_to_name(self.Zion, nspace=0)
             if self.Ej.value > 0:  # Need to put *'s in name
-                try:
+                if stars is not None:
                     iname += stars
-                except:
-                    raise IOError("Need to provide 'stars' parameter.")
+                else:
+                    warnings.warn("No stars provided.  Adding one because Ej > 0.")
+                    iname += '*'
             self.name = '{:s}_z{:0.5f}'.format(iname, self.zcomp)
         elif (name is None) and (self.Zion == (-1, -1)):
             self.name = 'mol_z{:0.5f}'.format(self.zcomp)

--- a/linetools/isgm/abssystem.py
+++ b/linetools/isgm/abssystem.py
@@ -180,7 +180,7 @@ class AbsSystem(object):
         return slf
 
     def __init__(self, radec, zabs, vlim, zem=0., abs_type=None,
-                 NHI=0., sig_NHI=np.zeros(2), flag_NHI=0, name=None):
+                 NHI=0., sig_NHI=np.zeros(2), flag_NHI=0, name=None, **kwargs):
 
         self.zabs = zabs
         self.zem = zem

--- a/linetools/isgm/tests/test_init_abscomp.py
+++ b/linetools/isgm/tests/test_init_abscomp.py
@@ -20,6 +20,9 @@ def test_init():
     assert abscomp.Zion[0] == 14
     np.testing.assert_allclose(abscomp.zcomp,1.0)
     print(abscomp)
+    # Fine structure
+    comp = AbsComponent((10.0*u.deg, 45*u.deg), (14,2), 1.0, [-300,300]*u.km/u.s, Ej=0.1/u.cm) # need stars!
+    assert comp.name.count('*') == 1
 
 
 def test_init_failures():
@@ -29,8 +32,6 @@ def test_init_failures():
         AbsComponent.from_abslines(['blah'])
     with pytest.raises(IOError):
         AbsComponent.from_component('blah')
-    with pytest.raises(IOError):
-        AbsComponent((10.0*u.deg, 45*u.deg), (14,2), 1.0, [-300,300]*u.km/u.s, Ej=0.1/u.cm) # need stars!
 
 
 def test_init_single_absline():

--- a/linetools/isgm/tests/test_use_abscomp.py
+++ b/linetools/isgm/tests/test_use_abscomp.py
@@ -42,6 +42,8 @@ def mk_comp(ctype,vlim=[-300.,300]*u.km/u.s,add_spec=False, use_rand=True,
         all_trans = ['SiII 1260', 'SiII 1304', 'SiII 1526', 'SiII 1808']
         if add_trans:
             all_trans += ['SiII 1193']
+    elif ctype == 'SiII*':
+        all_trans = ['SiII* 1264', 'SiII* 1533']
     abslines = []
     for trans in all_trans:
         iline = AbsLine(trans, z=zcomp)
@@ -87,6 +89,7 @@ def compare_two_files(file1, file2):
         assert l1 == l2
     f1.close()
     f2.close()
+
 
 def test_unique_comps():
     # One list of components
@@ -307,20 +310,6 @@ def test_cog():
     np.testing.assert_allclose(COG_dict['sig_logN'],0.054323725737309987)
 
 
-def test_synthesize_components():
-    #
-    SiIIcomp1,_ = mk_comp('SiII',vlim=[-300.,50.]*u.km/u.s, add_spec=True)
-    SiIIcomp1.synthesize_colm(redo_aodm=True)
-    #
-    SiIIcomp2,_ = mk_comp('SiII',vlim=[50.,300.]*u.km/u.s, add_spec=True)
-    SiIIcomp2.synthesize_colm(redo_aodm=True)
-    #
-    synth_SiII = ltiu.synthesize_components([SiIIcomp1,SiIIcomp2])
-    np.testing.assert_allclose(synth_SiII.logN, 13.862454764546792)
-    np.testing.assert_allclose(synth_SiII.sig_logN, 0.010146946475971825)
-    # Failures
-    pytest.raises(IOError, ltiu.synthesize_components, 1)
-    pytest.raises(IOError, ltiu.synthesize_components, [1,2])
 
 """
 def test_stack_plot():
@@ -488,3 +477,27 @@ def test_group_coincident_components():
     # check output as dictionary
     out = ltiu.group_coincident_components(comp_list, output_type='dict')
     assert isinstance(out, dict)
+
+
+def test_synthesize_components():
+    #
+    SiIIcomp1,_ = mk_comp('SiII',vlim=[-300.,50.]*u.km/u.s, add_spec=True)
+    SiIIcomp1.synthesize_colm(redo_aodm=True)
+    #
+    SiIIcomp2,_ = mk_comp('SiII',vlim=[50.,300.]*u.km/u.s, add_spec=True)
+    SiIIcomp2.synthesize_colm(redo_aodm=True)
+    #
+    synth_SiII = ltiu.synthesize_components([SiIIcomp1,SiIIcomp2])
+    np.testing.assert_allclose(synth_SiII.logN, 13.862454764546792)
+    np.testing.assert_allclose(synth_SiII.sig_logN, 0.010146946475971825)
+    # Failures
+    pytest.raises(IOError, ltiu.synthesize_components, 1)
+    pytest.raises(IOError, ltiu.synthesize_components, [1,2])
+    # Now SiII*
+    SiIIscomp1,_ = mk_comp('SiII*',vlim=[-300.,50.]*u.km/u.s, add_spec=True)
+    SiIIscomp1.synthesize_colm(redo_aodm=True)
+    #
+    SiIIscomp2,_ = mk_comp('SiII*',vlim=[50.,300.]*u.km/u.s, add_spec=True)
+    SiIIscomp2.synthesize_colm(redo_aodm=True)
+    synth_SiIIs = ltiu.synthesize_components([SiIIscomp1,SiIIscomp2])
+    assert synth_SiIIs.name.count('*') == 1

--- a/linetools/isgm/utils.py
+++ b/linetools/isgm/utils.py
@@ -162,7 +162,8 @@ def build_components_from_dict(idict, coord=None, **kwargs):
             if isinstance(idict['lines'][key], AbsLine):
                 line = idict['lines'][key]
             elif isinstance(idict['lines'][key], dict):
-                line = AbsLine.from_dict(idict['lines'][key], coord=coord)
+                pdb.set_trace()
+                line = AbsLine.from_dict(idict['lines'][key], coord=coord, **kwargs)
             else:
                 raise IOError("Need those lines")
             if coord is not None:
@@ -508,7 +509,8 @@ def synthesize_components(components, zcomp=None, vbuff=0*u.km/u.s):
 
 
     # Meld column densities
-    obj = dict(flag_N=components[0].flag_N, logN=components[0].logN, sig_logN=components[0].sig_logN)
+    obj = dict(flag_N=components[0].flag_N, logN=components[0].logN,
+               sig_logN=components[0].sig_logN)
     for comp in components[1:]:
         if comp.flag_N != 0:
             obj['flag_N'], obj['logN'], obj['sig_logN'] = ltaa.sum_logN(obj, comp)
@@ -524,7 +526,8 @@ def synthesize_components(components, zcomp=None, vbuff=0*u.km/u.s):
 
     # Init final component
     synth_comp = AbsComponent(components[0].coord, components[0].Zion, zcomp,
-                              vlim, Ntup=(obj['flag_N'], obj['logN'], obj['sig_logN']))
+                              vlim, Ej=components[0].Ej, stars=components[0].stars,
+                              Ntup=(obj['flag_N'], obj['logN'], obj['sig_logN']))
 
     # Return
     return synth_comp

--- a/linetools/isgm/utils.py
+++ b/linetools/isgm/utils.py
@@ -162,7 +162,6 @@ def build_components_from_dict(idict, coord=None, **kwargs):
             if isinstance(idict['lines'][key], AbsLine):
                 line = idict['lines'][key]
             elif isinstance(idict['lines'][key], dict):
-                pdb.set_trace()
                 line = AbsLine.from_dict(idict['lines'][key], coord=coord, **kwargs)
             else:
                 raise IOError("Need those lines")


### PR DESCRIPTION
Edits mainly to speed up reading JSON files.

Also turned off 'stars' as a required parameter when
generating a fine-structure component.  Defaults
to a single star if not provided.

Failing one Travis test which is not related to linetools.