### PR TITLE
Add reference redshift option for stack plots

### DIFF
--- a/linetools/analysis/plots.py
+++ b/linetools/analysis/plots.py
@@ -43,6 +43,7 @@ def stack_plot(abslines, vlim=[-300,300.]*u.km/u.s, nrow=6, show=True, spec=None
       If True, add EW values on the figure
     zref : float, optional
       Reference redshift for velocity scale; if None, each AbsLine.z is used
+
     Returns
     -------
     fig : matplotlib Figure, optional

--- a/linetools/analysis/plots.py
+++ b/linetools/analysis/plots.py
@@ -14,7 +14,8 @@ import matplotlib.gridspec as gridspec
 import matplotlib as mpl
 
 def stack_plot(abslines, vlim=[-300,300.]*u.km/u.s, nrow=6, show=True, spec=None,
-               ymnx=(-0.1,1.1), figsz=(18,11), return_fig=False, tight_layout=False, add_ew=False):
+               ymnx=(-0.1,1.1), figsz=(18,11), return_fig=False,
+               tight_layout=False, add_ew=False, zref=None):
     """Show a stack plot of the input lines
     Assumes the data are normalized.
     Comments about EW:
@@ -40,6 +41,8 @@ def stack_plot(abslines, vlim=[-300,300.]*u.km/u.s, nrow=6, show=True, spec=None
       If True, remove whitespace between panels
     add_ew : bool, optional
       If True, add EW values on the figure
+    zref : float, optional
+      Reference redshift for velocity scale; if None, each AbsLine.z is used
     Returns
     -------
     fig : matplotlib Figure, optional
@@ -81,7 +84,9 @@ def stack_plot(abslines, vlim=[-300,300.]*u.km/u.s, nrow=6, show=True, spec=None
         norm_sig = iline.analy['spec'].sig/co
         #
         # Plot
-        velo = iline.analy['spec'].relative_vel((1+iline.z)*iline.wrest)
+        if zref is None:
+            zref = iline.z
+        velo = iline.analy['spec'].relative_vel((1+zref)*iline.wrest)
         ax.plot(velo, norm_flux,  'k-', linestyle='steps-mid')
         ax.plot(velo, norm_sig,  'r:')
         # Lines

--- a/linetools/analysis/tests/test_plots.py
+++ b/linetools/analysis/tests/test_plots.py
@@ -19,11 +19,12 @@ def test_stack_plot(show=False):
     spec = ltsio.readspec(data_path('UM184_nF.fits'))  # already normalized
     abslin1.analy['spec'] = spec
     abslin1.analy['wvlim'] = [6079.78, 6168.82]*u.AA
-    abslin1.attrib['z'] = 2.92929
+    abslin1.setz(2.92929)
     ltap.stack_plot([abslin1], show=show)
     # second line
     abslin2.analy['spec'] = spec
     abslin2.analy['wvlim'] = [6079.78, 6168.82]*u.AA
-    abslin2.attrib['z'] = 2.92929
+    abslin2.setz(2.92929)
     ltap.stack_plot([abslin1, abslin2], show=show)
-
+    # now with a zref
+    ltap.stack_plot([abslin1, abslin2], show=show, zref=2.928)


### PR DESCRIPTION
Minor addition for plots.stack_plot to accept zref argument instead of using redshift for each AbsLine.  Useful for stack plots relative to a systemic redshifts.