### PR TITLE
AbsSystem and AbsComponent attributes

### DIFF
--- a/linetools/isgm/abscomponent.py
+++ b/linetools/isgm/abscomponent.py
@@ -142,7 +142,9 @@ class AbsComponent(object):
             slf.attrib['logN'] = logN
             slf.attrib['sig_logN'] = sig_logN
         else:
-            raise ValueError('The line measurements for the components are'
+            print(vels,cols,bs)
+            import pdb; pdb.set_trace()
+            raise ValueError('The line measurements for the components are '
                              'not consistent with one another.')
         # Return
         return slf

--- a/linetools/isgm/abscomponent.py
+++ b/linetools/isgm/abscomponent.py
@@ -138,7 +138,12 @@ class AbsComponent(object):
             slf.attrib['sig_b'] = medberr * u.km/u.s
             slf.attrib['vel'] = medvel * u.km/u.s
             slf.attrib['velerr'] = medvelerr * u.km / u.s
-        logN,sig_logN  = ltaa.log_clm(slf)
+            logN,sig_logN  = ltaa.log_clm(slf)
+            slf.attrib['logN'] = logN
+            slf.attrib['sig_logN'] = sig_logN
+        else:
+            raise ValueError('The line measurements for the components are'
+                             'not consistent with one another.')
         # Return
         return slf
 

--- a/linetools/isgm/abscomponent.py
+++ b/linetools/isgm/abscomponent.py
@@ -154,7 +154,7 @@ class AbsComponent(object):
             raise ValueError('The line measurements for the lines in this '
                              'component are not consistent with one another.')
             print(slf)
-        else:
+        elif medb != 0: # Empty b-values (upper lims) can throw off bcrit
             warnings.warn('The line measurements for the lines in this component'
                           ' are not consistent with one another.')
             print(slf)

--- a/linetools/isgm/abscomponent.py
+++ b/linetools/isgm/abscomponent.py
@@ -75,7 +75,7 @@ class AbsComponent(object):
     """
     @classmethod
     def from_abslines(cls, abslines, stars=None, comment="", reliability='none',
-                      tol=0.01, chk_meas=False, **kwargs):
+                      tol=0.01, chk_meas=False, verbose=True, **kwargs):
         """Instantiate from a list of AbsLine objects
 
         Parameters
@@ -135,8 +135,8 @@ class AbsComponent(object):
         medvel = np.median(vels)
         medvelerr = np.median(velerrs)
         # Perform checks on measurements
-        colcrit = all(np.abs(cols - medcol) / medcol < tol) == True
-        bcrit = all(np.abs(bs - medb) / medb < tol) == True
+        colcrit = all(np.abs(cols - medcol) / medcol < tol) is True
+        bcrit = all(np.abs(bs - medb) / medb < tol) is True
         # Set attribs
         slf.attrib['N'] = medcol / u.cm ** 2
         slf.attrib['sig_N'] = medcolerr / u.cm ** 2
@@ -154,11 +154,28 @@ class AbsComponent(object):
             raise ValueError('The line measurements for the lines in this '
                              'component are not consistent with one another.')
             print(slf)
-        elif medb != 0: # Empty b-values (upper lims) can throw off bcrit
-            warnings.warn('The line measurements for the lines in this component'
-                          ' are not consistent with one another.')
-            print(slf)
-            print(vels,cols,bs)
+        elif medb != 0:
+            # Empty b-values (upper lims) can throw off bcrit (= inf).
+            # These happen normally for nondetections, so ignore.
+            if verbose:
+                warnings.warn('The line measurements for the lines in this component'
+                              ' are not consistent with one another.')
+                print(slf)
+                print(vels,cols,bs)
+        else:
+            if verbose:
+                warnings.warn('The line measurements for the lines in this component'
+                          ' may not be consistent with one another.')
+                if bcrit:
+                    print('Problem lies in the column density values')
+                    print(cols)
+                elif colcrit:
+                    print('Problem lies in the b values')
+                    print(bs)
+                else:
+                    print('Problems lie in the column densities and b values')
+                    print(cols)
+                    print(bs)
 
         # Return
         return slf

--- a/linetools/isgm/abscomponent.py
+++ b/linetools/isgm/abscomponent.py
@@ -30,6 +30,13 @@ from linetools.analysis.zlimits import zLimits
 # Global import for speed
 c_kms = const.c.to('km/s').value
 
+# Global initial attrib dict (speeds up performance b/c astropy.Quantity issue?)
+init_attrib = {'N': 0./u.cm**2, 'sig_N': 0./u.cm**2, 'flag_N': 0, # Column    ## NOT ENOUGH SPEED-UP
+              'logN': 0., 'sig_logN': 0.,
+              'b': 0.*u.km/u.s, 'sig_b': 0.*u.km/u.s,  # Doppler
+              'vel': 0*u.km/u.s, 'sig_vel': 0*u.km/s
+              }
+
 # Class for Components
 class AbsComponent(object):
     """
@@ -55,6 +62,8 @@ class AbsComponent(object):
         Atomic mass -- used to distinguish isotopes
     Ej : Quantity
         Energy of lower level (1/cm)
+    attrib : dict
+        Absorption properties (e.g. column, Doppler b, centroid)
     reliability : str, optional
         Reliability of AbsComponent
             'a' - reliable
@@ -251,7 +260,7 @@ class AbsComponent(object):
         self.reliability = reliability
 
         # Potential for attributes
-        self.attrib = dict()
+        self.attrib = init_attrib.copy()
 
         # Other
         self._abslines = []
@@ -263,6 +272,14 @@ class AbsComponent(object):
     @property
     def zcomp(self):
         return self.limits.z
+
+    @property
+    def b(self):
+        return self.attrib['b']
+
+    @property
+    def vel(self):  #velocity centroid
+        return self.attrib['vel']
 
     def add_absline(self, absline, tol=0.1*u.arcsec, chk_vel=True,
                     chk_sep=True, vtoler=1., **kwargs):

--- a/linetools/isgm/abscomponent.py
+++ b/linetools/isgm/abscomponent.py
@@ -329,8 +329,16 @@ class AbsComponent(object):
         return self.attrib['b']
 
     @property
+    def sig_b(self):
+        return self.attrib['sig_b']
+
+    @property
     def vel(self):  #velocity centroid
         return self.attrib['vel']
+
+    @property
+    def sig_vel(self):  #velocity centroid
+        return self.attrib['sig_vel']
 
     def add_absline(self, absline, tol=0.1*u.arcsec, chk_vel=True,
                     chk_sep=True, vtoler=1., **kwargs):

--- a/linetools/isgm/abscomponent.py
+++ b/linetools/isgm/abscomponent.py
@@ -218,7 +218,7 @@ class AbsComponent(object):
                   Ej=idict['Ej']/u.cm, A=idict['A'],
                   Ntup = tuple([idict[key] for key in ['flag_N', 'logN', 'sig_logN']]),
                   comment=idict['comment'], name=idict['Name'], reliability=reliability)
-
+        slf.attrib = idict['attrib']
         # Add lines
         for key in idict['lines'].keys():
             iline = AbsLine.from_dict(idict['lines'][key], coord=coord, **kwargs)
@@ -904,7 +904,8 @@ class AbsComponent(object):
                      Name=self.name,
                      RA=self.coord.icrs.ra.value, DEC=self.coord.icrs.dec.value,
                      A=self.A, Ej=self.Ej.to('1/cm').value, comment=self.comment,
-                     flag_N=self.flag_N, logN=self.logN, sig_logN=self.sig_logN)
+                     flag_N=self.flag_N, logN=self.logN, sig_logN=self.sig_logN,
+                     attrib=self.attrib)
         cdict['class'] = self.__class__.__name__
         # AbsLines
         cdict['lines'] = {}

--- a/linetools/isgm/abscomponent.py
+++ b/linetools/isgm/abscomponent.py
@@ -34,7 +34,7 @@ c_kms = const.c.to('km/s').value
 init_attrib = {'N': 0./u.cm**2, 'sig_N': 0./u.cm**2, 'flag_N': 0, # Column    ## NOT ENOUGH SPEED-UP
               'logN': 0., 'sig_logN': 0.,
               'b': 0.*u.km/u.s, 'sig_b': 0.*u.km/u.s,  # Doppler
-              'vel': 0*u.km/u.s, 'sig_vel': 0*u.km/s
+              'vel': 0*u.km/u.s, 'sig_vel': 0*u.km/u.s
               }
 
 # Class for Components

--- a/linetools/isgm/abscomponent.py
+++ b/linetools/isgm/abscomponent.py
@@ -143,7 +143,7 @@ class AbsComponent(object):
         slf.attrib['b'] = medb * u.km / u.s
         slf.attrib['sig_b'] = medberr * u.km / u.s
         slf.attrib['vel'] = medvel * u.km / u.s
-        slf.attrib['velerr'] = medvelerr * u.km / u.s
+        slf.attrib['sig_vel'] = medvelerr * u.km / u.s
         logN, sig_logN = ltaa.log_clm(slf.attrib)
         slf.attrib['logN'] = logN
         slf.attrib['sig_logN'] = sig_logN

--- a/linetools/isgm/abscomponent.py
+++ b/linetools/isgm/abscomponent.py
@@ -218,7 +218,12 @@ class AbsComponent(object):
                   Ej=idict['Ej']/u.cm, A=idict['A'],
                   Ntup = tuple([idict[key] for key in ['flag_N', 'logN', 'sig_logN']]),
                   comment=idict['comment'], name=idict['Name'], reliability=reliability)
-        slf.attrib = idict['attrib']
+        attrkeys = idict['attrib'].keys()
+        for ak in attrkeys:
+            if isinstance(idict['attrib'][ak],dict):
+                slf.attrib[ak] = ltu.convert_quantity_in_dict(idict['attrib'][ak])
+            else:
+                slf.attrib[ak] = idict['attrib'][ak]
         # Add lines
         for key in idict['lines'].keys():
             iline = AbsLine.from_dict(idict['lines'][key], coord=coord, **kwargs)

--- a/linetools/isgm/abssystem.py
+++ b/linetools/isgm/abssystem.py
@@ -101,7 +101,7 @@ class AbsSystem(object):
           List of AbsComponent objects
         vlim : list, optional
           Velocity limits for the system
-          If not set, the first components sets vlim
+          If not set, the first component sets vlim
         NHI : float, optional
           Set the NHI value of the system.  If not set,
           the method sums the NHI values of all the HI

--- a/linetools/isgm/abssystem.py
+++ b/linetools/isgm/abssystem.py
@@ -564,6 +564,7 @@ class AbsSystem(object):
         else:
             components = self._components
             self.vlim = get_vmnx(components)  # Using system z
+            
 
     def write_json(self, outfil=None, overwrite=True):
         """ Generate a JSON file from the system

--- a/linetools/isgm/abssystem.py
+++ b/linetools/isgm/abssystem.py
@@ -494,6 +494,21 @@ class AbsSystem(object):
         for comp in self._components:
             comp.synthesize_colm(**kwargs)
 
+    def update_component_vel(self):
+        """Change the velocities of each component to be relative to zsys
+
+        """
+        from linetools.analysis.zlimits import zLimits
+
+        for i,comp in enumerate(self._components):
+            dv = ltu.dv_from_z(comp.zcomp, self.zabs)
+            zmin = ltu.z_from_dv(comp.limits.vlim[0]+dv,self.zabs)
+            zmax = ltu.z_from_dv(comp.limits.vlim[1]+dv,self.zabs)
+            newzlim = zLimits(self.zabs, (zmin, zmax))
+            comp.limits = newzlim
+            comp.attrib['vel'] = comp.attrib['vel'] + dv
+
+
     def stack_plot(self, pvlim=None, **kwargs):
         """Show a stack plot of the system, if spec are loaded
         Assumes the data are normalized.

--- a/linetools/isgm/abssystem.py
+++ b/linetools/isgm/abssystem.py
@@ -495,8 +495,7 @@ class AbsSystem(object):
             comp.synthesize_colm(**kwargs)
 
     def update_component_vel(self):
-        """Change the velocities of each component to be relative to zsys
-
+        """Change the velocities of each component to rest frame of zsys
         """
         from linetools.analysis.zlimits import zLimits
 

--- a/linetools/isgm/utils.py
+++ b/linetools/isgm/utils.py
@@ -376,7 +376,8 @@ def table_from_complist(complist):
     tab['ion'] = [icomp.Zion[1] for icomp in complist]
 
     # . attributes (required ones)
-    for attrib in ['zcomp', 'Ej', 'flag_N', 'logN', 'sig_logN']:
+    for attrib in ['zcomp', 'Ej', 'flag_N', 'logN', 'sig_logN',
+                   'b','sig_b','vel','sig_vel']:
         values = [getattr(icomp,attrib) for icomp in complist]
         if isinstance(values[0], u.Quantity):
             values = u.Quantity(values)

--- a/linetools/isgm/utils.py
+++ b/linetools/isgm/utils.py
@@ -361,7 +361,7 @@ def table_from_complist(complist):
     """
     key_order = ['RA', 'DEC', 'name', 'z_comp', 'sig_z', 'Z', 'ion', 'Ej',
                  'vmin', 'vmax','ion_name', 'flag_N', 'logN', 'sig_logN',
-                 'b','sig_b', 'specfile']
+                 'b','sig_b', 'vel', 'sig_vel','specfile']
 
     tab = Table()
 
@@ -394,7 +394,7 @@ def table_from_complist(complist):
     tab['ion_name'] = ion_names
 
     # attrib dict
-    for attrib in ['sig_z', 'b', 'sig_b', 'specfile']:
+    for attrib in ['sig_z', 'b', 'sig_b', 'vel', 'sig_vel', 'specfile']:
         try:
             values = [icomp.attrib[attrib] for icomp in complist]
         except KeyError:

--- a/linetools/spectralline.py
+++ b/linetools/spectralline.py
@@ -38,7 +38,8 @@ init_attrib = {
 
 abs_attrib = {'N': 0./u.cm**2, 'sig_N': 0./u.cm**2, 'flag_N': 0, # Column    ## NOT ENOUGH SPEED-UP
               'logN': 0., 'sig_logN': 0.,
-                    'b': 0.*u.km/u.s, 'sig_b': 0.*u.km/u.s  # Doppler
+                    'b': 0.*u.km/u.s, 'sig_b': 0.*u.km/u.s,  # Doppler
+                    'vel': 0.*u.km/u.s, 'sig_vel': 0.*u.km/u.s  # Doppler
                     }
 
 emiss_attrib = {'flux': 0.*u.erg/u.s, 'sig_flux': 0.*u.erg/u.s, 'flag_flux': 0,


### PR DESCRIPTION
Extends the AbsComponent object so that b values and velocity centroids are attribs.  Also, method to shift component velocities to systemic value.  Includes above attribs in component table.