### PR TITLE
Two small, useful edits related to Components

### DIFF
--- a/linetools/isgm/abscomponent.py
+++ b/linetools/isgm/abscomponent.py
@@ -256,7 +256,7 @@ class AbsComponent(object):
         # Deprecated column density attributes
         if 'logN' in idict.keys():
             warnings.warn('Column density attributes are now Deprecated', DeprecationWarning)
-            print("We will use yours for now..")
+            #print("We will use yours for now..")
             Ntup = tuple([idict[key] for key in ['flag_N', 'logN', 'sig_logN']])
         else:
             Ntup = None

--- a/linetools/isgm/abssystem.py
+++ b/linetools/isgm/abssystem.py
@@ -739,11 +739,10 @@ def add_comps_from_dict(slf, idict, skip_components=False, use_coord=False, **kw
     """
     if not skip_components:
         # Components
-        if use_coord:  # Speed up performance
+        if use_coord and ('coord' not in kwargs.keys()):  # Speed up performance
             coord = slf.coord
-        else:
-            coord = None
-        components = ltiu.build_components_from_dict(idict, coord=coord, **kwargs)
+            kwargs['coord'] = coord
+        components = ltiu.build_components_from_dict(idict, **kwargs)
         for component in components:
             # This is to insure the components follow the rules
             slf.add_component(component, **kwargs)


### PR DESCRIPTION
As titled.
Several IGMSurveys in pyigm were
crashing because of the coord speed-up.

No new tests or docs.