### PR TITLE
Abscomponent bug fix

### DIFF
--- a/linetools/isgm/abscomponent.py
+++ b/linetools/isgm/abscomponent.py
@@ -518,6 +518,8 @@ class AbsComponent(object):
         **kwargs are passed to AbsLine.add_absline() method.
 
         """
+        from linetools.lists import utils as ltlu
+
         # get the transitions from LineList
         llist = LineList(llist)
         if init_name is None:  # we have to guess it
@@ -530,7 +532,7 @@ class AbsComponent(object):
 
         # unify output to be a Table
         if isinstance(transitions, dict):
-            transitions = llist.from_dict_to_table(transitions)
+            transitions = ltlu.from_dict_to_table(transitions)
 
         # check wvlims
         if wvlim is not None:

--- a/linetools/isgm/abscomponent.py
+++ b/linetools/isgm/abscomponent.py
@@ -532,7 +532,7 @@ class AbsComponent(object):
 
         # unify output to be a Table
         if isinstance(transitions, dict):
-            transitions =ltlu.from_dict_to_table(transitions)
+            transitions = ltlu.from_dict_to_table(transitions)
 
         # check wvlims
         if wvlim is not None:

--- a/linetools/isgm/abscomponent.py
+++ b/linetools/isgm/abscomponent.py
@@ -532,7 +532,7 @@ class AbsComponent(object):
 
         # unify output to be a Table
         if isinstance(transitions, dict):
-            transitions = ltlu.from_dict_to_table(transitions)
+            transitions =ltlu.from_dict_to_table(transitions)
 
         # check wvlims
         if wvlim is not None:

--- a/linetools/isgm/tests/test_use_abscomp.py
+++ b/linetools/isgm/tests/test_use_abscomp.py
@@ -502,3 +502,13 @@ def test_copy():
     comp.logN = 14.6
     assert comp2.logN != comp.logN
 
+
+def test_add_abslines_from_linelist():
+    # Component
+    abscomp,_ = mk_comp('SiII', vlim=[-250,80.]*u.km/u.s)
+    # Set wavelength (observed) range
+    wvrange = [4674. * u.Angstrom, 4690. * u.Angstrom]
+    # Add a couple absorption lines
+    abscomp.add_abslines_from_linelist(wvlim=wvrange)
+    assert len(abscomp._abslines) == 6
+


### PR DESCRIPTION
The from_dict_to_table() method had apparently been moved to linetools.lists.utils, but this had not been refactored in AbsComponent.add_abslines_from_linelist()