### PR TITLE
Return Figure object for abssystem and emsystem

### DIFF
--- a/linetools/isgm/abssystem.py
+++ b/linetools/isgm/abssystem.py
@@ -597,7 +597,10 @@ class AbsSystem(object):
             vlim = pvlim
         else:
             vlim = self.vlim
-        ltap.stack_plot(self.list_of_abslines(), vlim=vlim, **kwargs)
+
+        fig = ltap.stack_plot(self.list_of_abslines(), vlim=vlim, **kwargs)
+        if fig is not None:
+            return fig
 
     def to_dict(self):
         """ Write AbsSystem data to a dict that can be written with JSON

--- a/linetools/isgm/emsystem.py
+++ b/linetools/isgm/emsystem.py
@@ -467,7 +467,9 @@ class EmSystem(object):
             vlim = pvlim
         else:
             vlim = self.vlim
-        ltap.stack_plot(self.list_of_abslines(), vlim=vlim, **kwargs)
+        fig = ltap.stack_plot(self.list_of_abslines(), vlim=vlim, **kwargs)
+        if fig is not None:
+            return fig
 
     def to_dict(self):
         """ Write EmSystem data to a dict that can be written with JSON


### PR DESCRIPTION
As stated, trivial changes to allow Figure object passthrough for abssystem and emsystem when using return_fig option