### PR TITLE
Remember wvlim in lt_xspec

### DIFF
--- a/linetools/guis/spec_widgets.py
+++ b/linetools/guis/spec_widgets.py
@@ -1434,7 +1434,8 @@ class MultiSpecWidget(QWidget):
         self.parent.spec.select = chosen
         self.parent.select = chosen
         # Re-init and draw
-        self.parent.init_spec()
+        # self.parent.init_spec(xlim=self.parent.psdict['x_minmax'], ylim=self.parent.psdict['y_minmax'])
+        self.parent.init_spec(xlim=self.parent.psdict['x_minmax'])
         self.parent.on_draw()
         # Extra?
         if self.extra_method is not None:


### PR DESCRIPTION
As stated.

(Regarding remembering flux limits too, I think is better for xspec to guess the y-limits depending on each data than fixing it.)