### PR TITLE
Tweak: Function to identify metals and interlopers in a given spectrum

### DIFF
--- a/linetools/isgm/utils.py
+++ b/linetools/isgm/utils.py
@@ -1062,7 +1062,7 @@ def unique_components(comps1, comps2, tol=5*u.arcsec):
 
 def is_not_HILya(wvobs, comps):
     """Given an array of wavelengths, this function returns a boolean array of same shape as
-     `wobs` with True for pixels known to be contaminated by non HI Lya absorption given a list
+     `wvobs` with True for pixels known to be contaminated by non HI Lya absorption given a list
      of AbsComponent objects
 
      Parameters

--- a/linetools/isgm/utils.py
+++ b/linetools/isgm/utils.py
@@ -1060,3 +1060,31 @@ def unique_components(comps1, comps2, tol=5*u.arcsec):
     return unique
 
 
+def is_not_HILya(wvobs, comps):
+    """Given an array of wavelengths, this function returns a boolean array of same shape as
+     `wobs` with True for pixels known to be contaminated by non HI Lya absorption given a list
+     of AbsComponent objects
+
+     Parameters
+     ----------
+     wobs : Quantity array
+        Observed wavelength
+    comp : list of AbsComponent objects
+        List of abscomponent objects identified
+
+    Returns
+    -------
+    answer : bool
+        True if there is a identified line that is not HI Lya, otherwise False
+
+     """
+
+    # loop over component and abslines
+    cond = False * len(wvobs)
+    for comp in comps:
+        for line in comp._abslines:
+            if line.name != 'HI 1215':
+                wvlims = line.limits.wvlim
+                cond_aux = (wvobs >= wvlims[0]) & (wvobs <= wvlims[1])
+                cond = cond_aux | cond
+    return np.array(cond).astype(bool)


### PR DESCRIPTION
As stated. A simple function that identifies pixels that belong to a metal line or a higher-order HI Lyman absorption. Useful for masking out interlopers.