### PR TITLE
Add 'ANGSTROMS' unit to account for FUSE data in spectra/io.py.

### DIFF
--- a/linetools/spectra/io.py
+++ b/linetools/spectra/io.py
@@ -302,7 +302,7 @@ def get_wave_unit(tag, hdulist, idx=None):
         except KeyError:
            return None
         else:
-            if tunit in ['Angstroem', 'Angstroms']:
+            if tunit in ['Angstroem', 'Angstroms', 'ANGSTROMS']:
                 tunit = 'Angstrom'
             unit = Unit(tunit)
             return unit


### PR DESCRIPTION
FUSE NVO files in the MAST archive adopt the units of  'ANGSTROMS' (all upper case), which doesn't get captured in the present list of spectra/io.py. Adding this to line 305 fixes the issue.