### PR TITLE
Update dev version handling

### DIFF
--- a/linetools/analysis/plots.py
+++ b/linetools/analysis/plots.py
@@ -93,7 +93,7 @@ def stack_plot(abslines, vlim=[-300,300.]*u.km/u.s, nrow=6, show=True, spec=None
         if zref is None:
             zref = iline.z
         velo = iline.analy['spec'].relative_vel((1+zref)*iline.wrest)
-        ax.plot(velo, norm_flux,  'k-', linestyle='steps-mid')
+        ax.plot(velo, norm_flux,  'k-', drawstyle='steps-mid')
         ax.plot(velo, norm_sig,  'r:')
         # Lines
         ax.plot([0]*2, ymnx, 'g--')

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,13 @@ VERSION = '0.3.dev'
 RELEASE = 'dev' not in VERSION
 
 if not RELEASE:
-    VERSION += get_git_devstr(False)
+    git_devstr = get_git_devstr(False)
+    if not git_devstr:
+        import linetools.version
+        version_version = linetools.version.version
+        VERSION = version_version
+    else:
+        VERSION = VERSION + git_devstr
 
 # Populate the dict of setup command overrides; this should be done before
 # invoking any other functionality from distutils since it can potentially


### PR DESCRIPTION
This should make it so that, if a linetools sdist is made inside a linetools git repo, the correct version will go into version.py
Then, when installing from that sdist not in a linetools git repo, the correct version is pulled from version.py
This should make it so that the linetools conda-forge package will provide the correct value for linetools.__version__

I'll test the creation of and installation from sdists and report back results.