### PR TITLE
fussing with stack plot

### DIFF
--- a/linetools/analysis/plots.py
+++ b/linetools/analysis/plots.py
@@ -49,6 +49,7 @@ def stack_plot(abslines, vlim=[-300,300.]*u.km/u.s, nrow=6, show=True, spec=None
     fig : matplotlib Figure, optional
         Figure instance containing stack plot with subplots, axes, etc.
     """
+    from linetools.spectra.io import readspec
     mpl.rcParams['font.family'] = 'stixgeneral'
     mpl.rcParams['font.size'] = 15.
     # Check for spec (required)
@@ -59,6 +60,9 @@ def stack_plot(abslines, vlim=[-300,300.]*u.km/u.s, nrow=6, show=True, spec=None
         else:
             if spec is not None:
                 iline.analy['spec'] = spec
+                gdiline.append(iline)
+            else:
+                iline.analy['spec'] = readspec(iline.analy['spec_file'])
                 gdiline.append(iline)
     nplt = len(gdiline)
     if nplt == 0:

--- a/linetools/analysis/plots.py
+++ b/linetools/analysis/plots.py
@@ -93,7 +93,7 @@ def stack_plot(abslines, vlim=[-300,300.]*u.km/u.s, nrow=6, show=True, spec=None
         if zref is None:
             zref = iline.z
         velo = iline.analy['spec'].relative_vel((1+zref)*iline.wrest)
-        ax.plot(velo, norm_flux,  'k-', linestyle='steps-mid')
+        ax.plot(velo, norm_flux,  'k-', drawstyle='steps-mid')
         ax.plot(velo, norm_sig,  'r:')
         # Lines
         ax.plot([0]*2, ymnx, 'g--')


### PR DESCRIPTION
matplotlib >3.0.3 produces error when trying to use 'step-mid' with the linestyle attribute as this was deprecated behavior.  

Also adding another way to make a stackplot from spec_file