### PR TITLE
Actually fix dev version handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,6 +112,7 @@ install:
 
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
+    - conda install pytest-astropy
 
 script:
     - $MAIN_CMD $SETUP_CMD

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ RELEASE = 'dev' not in VERSION
 
 if not RELEASE:
     git_devstr = get_git_devstr(False)
-    if not git_devstr:
+    if (git_devstr == '0') or (git_devstr == ''):
         import linetools.version
         version_version = linetools.version.version
         VERSION = version_version


### PR DESCRIPTION
Followup to #520 , this time with verification that the resulting sdists, when installed generate the correct `linetools.__version__` field