### PR TITLE
Avoid crash with overly long METADATA card

### DIFF
--- a/linetools/spectra/io.py
+++ b/linetools/spectra/io.py
@@ -611,7 +611,10 @@ def parse_linetools_spectrum_format(hdulist, **kwargs):
         # Prepare for JSON (bug fix of sorts)
         metas = hdulist[0].header['METADATA']
         ipos = metas.rfind('}')
-        xspec1d.meta.update(json.loads(metas[:ipos+1]))
+        try:
+            xspec1d.meta.update(json.loads(metas[:ipos+1]))
+        except:
+            print("Bad METADATA;  proceeding without")
 
     return xspec1d
 

--- a/linetools/spectra/io.py
+++ b/linetools/spectra/io.py
@@ -614,6 +614,7 @@ def parse_linetools_spectrum_format(hdulist, **kwargs):
         try:
             xspec1d.meta.update(json.loads(metas[:ipos+1]))
         except:
+            # TODO: fix this in a better manner, if possible
             print("Bad METADATA;  proceeding without")
 
     return xspec1d


### PR DESCRIPTION
An update to `astropy` appears to have it no longer
slurp in extra long CONTINUE's of strings.  This
lends to a crash when trying to read them in.

This PR offers a hack/fix as a temporary solution.