### PR TITLE
BLD: pin extension-helpers to 1.* following upstream recommendation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "setuptools",
     "setuptools_scm",
     "wheel",
-    "extension-helpers",
+    "extension-helpers==1.*",
     "oldest-supported-numpy",
 ]
 


### PR DESCRIPTION
Following https://github.com/astropy/extension-helpers/pull/72