### PR TITLE
imp -> importlib

### DIFF
--- a/linetools/abund/solar.py
+++ b/linetools/abund/solar.py
@@ -11,13 +11,13 @@ except NameError:
 
 import numpy as np
 import numbers
-import imp
+import importlib
 
 from astropy.io import ascii
 from astropy.utils.misc import isiterable
 
 #from xastropy.xutils import xdebug as xdb
-l_path = imp.find_module('linetools')[1]
+l_path = importlib.util.find_spec('linetools').submodule_search_locations[0]
 
 #
 class SolarAbund(object):

--- a/linetools/analysis/absline.py
+++ b/linetools/analysis/absline.py
@@ -12,6 +12,9 @@ from astropy.io import ascii
 from astropy.utils import isiterable
 from linetools.lists.linelist import LineList
 
+import importlib
+lt_path = importlib.util.find_spec('linetools').submodule_search_locations[0]
+
 # Atomic constant
 atom_cst = (const.m_e.cgs*const.c.cgs / (np.pi * 
     (const.e.esu**2).cgs)).to(u.AA*u.s/(u.km*u.cm**2))
@@ -221,8 +224,7 @@ def photo_cross(Z, ion, E, datfil=None, silent=False):
     sigma : Quantity
       Cross-section (cm^2)
     """
-    import imp
-    lt_path = imp.find_module('linetools')[1]
+
     # Read data
     if datfil is None:
         datfil = lt_path+'/data/atomic/verner96_photoion_table1.dat'

--- a/linetools/analysis/tests/test_continuum.py
+++ b/linetools/analysis/tests/test_continuum.py
@@ -3,12 +3,12 @@ from __future__ import print_function, absolute_import, division, unicode_litera
 from astropy.table import Table
 from ...spectra.io import readspec
 from ..continuum import find_continuum
-import imp
+import importlib
 import numpy as np
 import pytest
 
 def test_find_continuum():
-    d = imp.find_module('linetools')[1]
+    d = importlib.util.find_spec('linetools').submodule_search_locations[0]
     spec = readspec(d + '/spectra/tests/files/q0002m422.txt.gz', masking='none')
     co, pts = find_continuum(spec, redshift=2.76, divmult=3.5,
                        forest_divmult=3, kind='QSO')

--- a/linetools/analysis/tests/test_continuumfnd.py
+++ b/linetools/analysis/tests/test_continuumfnd.py
@@ -2,12 +2,12 @@ from __future__ import print_function, absolute_import, division, unicode_litera
 
 from ...spectra.io import readspec
 from ..continuumfnd import contknots
-import imp
+import importlib
 import numpy as np
 import pytest 
 
 def test_find_continuum_knots():
-    d = imp.find_module('linetools')[1]
+    d = importlib.util.find_spec('linetools').submodule_search_locations[0]
     spec = readspec(d + '/spectra/tests/files/spec_example_2.fits')  # XSpectrum1D.from_file(spfile)
     testknots, testknotpixs = contknots(spec, ewsnlim=5, showcont=False)
     knotscont = np.asarray(testknots)[:, 1]

--- a/linetools/isgm/tests/test_use_abscomp.py
+++ b/linetools/isgm/tests/test_use_abscomp.py
@@ -20,8 +20,9 @@ from linetools.isgm import utils as ltiu
 
 from linetools.isgm.tests.utils import mk_comp, mk_comptable, ism
 
-import imp, os
-lt_path = imp.find_module('linetools')[1]
+import os
+import importlib
+lt_path = importlib.util.find_spec('linetools').submodule_search_locations[0]
 
 #import pdb
 #pdb.set_trace()

--- a/linetools/lists/mk_sets.py
+++ b/linetools/lists/mk_sets.py
@@ -3,7 +3,8 @@
 from __future__ import print_function, absolute_import, division, unicode_literals
 
 import numpy as np
-import imp, glob
+import importlib
+import glob
 import copy
 
 from astropy.io import ascii
@@ -11,7 +12,7 @@ from astropy.io import ascii
 from linetools.lists import parse as llp
 
 
-lt_path = imp.find_module('linetools')[1]
+lt_path = importlib.util.find_spec('linetools').submodule_search_locations[0]
 
 
 def mk_hi(infil=None, outfil=None, stop=True):

--- a/linetools/lists/parse.py
+++ b/linetools/lists/parse.py
@@ -3,10 +3,11 @@
 from __future__ import print_function, absolute_import, division, unicode_literals
 
 import numpy as np
-import os, imp, glob, pdb, gzip, sys
+import os, glob, pdb, gzip, sys
 if not sys.version_info[0] > 2:
     import codecs
     open = codecs.open
+import importlib
 
 from pkg_resources import resource_filename
 
@@ -18,7 +19,7 @@ from astropy.table import Column, Table, vstack
 from linetools.abund import roman, ions
 from linetools.abund.elements import ELEMENTS
 
-#lt_path = imp.find_module('linetools')[1]
+lt_path = importlib.util.find_spec('linetools').submodule_search_locations[0]
 
 
 # TODO

--- a/linetools/lists/tests/test_init_linelist.py
+++ b/linetools/lists/tests/test_init_linelist.py
@@ -94,9 +94,9 @@ def test_mk_sets():
     outfile = 'tmp.lst'
     if os.path.isfile(outfile):
         os.remove(outfile)
-    import imp
+    import importlib
     llmk.mk_hi(outfil=outfile, stop=False)
-    lt_path = imp.find_module('linetools')[1]
+    lt_path = importlib.util.find_spec('linetools').submodule_search_locations[0]
     llmk.add_galaxy_lines(outfile, infil=lt_path+'/lists/sets/llist_v0.1.ascii', stop=False)
     os.remove(outfile)
 

--- a/linetools/spectra/lsf.py
+++ b/linetools/spectra/lsf.py
@@ -9,11 +9,12 @@ from astropy.io import fits, ascii
 from astropy.units import Quantity
 import astropy.units as u
 from astropy.table import Table, QTable, Column
-import glob, imp
+import glob
+import importlib
 from linetools.analysis.interp import interp_Akima
 import warnings
 
-lt_path = imp.find_module('linetools')[1]
+lt_path = importlib.util.find_spec('linetools').submodule_search_locations[0]
 
 class LSF(object):
     """Class to deal with line-spread-functions (LSFs) from


### PR DESCRIPTION
Replaced some more uses of imp with to importlib. Running tests with pytest doesn't flag anything up, though that was just with astropy 6.0.0 and numpy 1.26.3