### PR TITLE
Pkg resources

### DIFF
--- a/linetools/isgm/tests/test_io.py
+++ b/linetools/isgm/tests/test_io.py
@@ -4,10 +4,9 @@ from __future__ import print_function, absolute_import, division, unicode_litera
 
 # TEST_UNICODE_LITERALS
 
-import pytest
 import os
 
-from pkg_resources import resource_filename
+import importlib_resources
 
 from astropy.coordinates import SkyCoord
 from astropy import units as u
@@ -41,9 +40,9 @@ def test_complist_to_joebvp():
     ltiio.write_joebvp_from_components(comp_list, 'test.fits', data_path('test_joebvp_repr.joebvp'))
     # now read the output and compare to reference
     ltu.compare_two_files(data_path('test_joebvp_repr.joebvp'),
-                      resource_filename('linetools', '/data/tests/test_joebvp_repr_reference.joebvp'))
+                      str(importlib_resources.files('linetools.data.tests')/'test_joebvp_repr_reference.joebvp'))
     # now add attribute to comp and compare again
     abscomp.attrib['b'] = 15*u.km/u.s
     ltiio.write_joebvp_from_components(comp_list, 'test.fits', data_path('test_joebvp_repr.joebvp'))
     ltu.compare_two_files(data_path('test_joebvp_repr.joebvp'),
-                      resource_filename('linetools', '/data/tests/test_joebvp_repr_reference.joebvp'))
+                      str(importlib_resources.files('linetools.data.tests')/'test_joebvp_repr_reference.joebvp'))

--- a/linetools/isgm/tests/utils.py
+++ b/linetools/isgm/tests/utils.py
@@ -4,9 +4,8 @@ from __future__ import print_function, absolute_import, division, unicode_litera
 
 import os
 import numpy as np
-import pdb
 
-from pkg_resources import resource_filename
+import importlib_resources
 
 from astropy import units as u
 from astropy.coordinates import SkyCoord
@@ -112,7 +111,7 @@ def mk_comp(ctype,vlim=[-300.,300]*u.km/u.s,add_spec=False, use_rand=True,
             add_trans=False, zcomp=2.92939, b=20*u.km/u.s, **kwargs):
     # Read a spectrum Spec
     if add_spec:
-        spec_file = resource_filename('linetools','/spectra/tests/files/UM184_nF.fits')
+        spec_file = str(importlib_resources.files('linetools.spectra.tests')/'.files/UM184_nF.fits')
         xspec = lsio.readspec(spec_file)
     else:
         xspec = None

--- a/linetools/lists/linelist.py
+++ b/linetools/lists/linelist.py
@@ -5,7 +5,6 @@ basestring = str
 
 import numpy as np
 
-#from pkg_resources import resource_filename
 import importlib_resources
 
 from astropy import units as u

--- a/linetools/lists/linelist.py
+++ b/linetools/lists/linelist.py
@@ -5,7 +5,8 @@ basestring = str
 
 import numpy as np
 
-from pkg_resources import resource_filename
+#from pkg_resources import resource_filename
+import importlib_resources
 
 from astropy import units as u
 from astropy.units.quantity import Quantity
@@ -130,7 +131,7 @@ class LineList(object):
         return self._data['ion']
 
     def load_data(self):
-        data_file = resource_filename('linetools', 'data/lines/linelist.ascii')
+        data_file = importlib_resources.files('linetools.data.lines')/'linelist.ascii'
         # Read
         self._fulltable = Table.read(data_file, format='ascii.ecsv')
 

--- a/linetools/lists/parse.py
+++ b/linetools/lists/parse.py
@@ -9,7 +9,6 @@ if not sys.version_info[0] > 2:
     open = codecs.open
 import importlib
 
-#from pkg_resources import resource_filename
 import importlib_resources
 
 from astropy import units as u

--- a/linetools/lists/parse.py
+++ b/linetools/lists/parse.py
@@ -9,7 +9,8 @@ if not sys.version_info[0] > 2:
     open = codecs.open
 import importlib
 
-from pkg_resources import resource_filename
+#from pkg_resources import resource_filename
+import importlib_resources
 
 from astropy import units as u
 from astropy.units.quantity import Quantity
@@ -104,7 +105,7 @@ def read_sets(infil=None):
       Set file
     """
     if infil is None:
-        fils = glob.glob(os.path.join(resource_filename('linetools', 'lists'), 'sets', 'llist_v*'))
+        fils = glob.glob(str(importlib_resources.files('linetools.lists.sets')/'llist_v*'))
         fils.sort()
         infil = fils[-1] # Should grab the lateset
     # Read
@@ -1046,7 +1047,7 @@ def _write_ref_table(outfile=None):
     date = str(datetime.date.today().strftime('%Y-%b-%d'))
     user = getpass.getuser()
     if outfile is None:
-        outfile = resource_filename('linetools', 'data/lines/linelist.ascii')
+        outfile = importlib_resources.file('linetools.data.lines')/'linelist.ascii'
 
     # Define datasets: In order of Priority
     datasets = [parse_morton03, parse_morton00, parse_verner96,

--- a/linetools/tests/test_utils.py
+++ b/linetools/tests/test_utils.py
@@ -3,14 +3,14 @@
 import pytest
 import numpy as np
 import os
-from pkg_resources import resource_filename
+import importlib_resources
 
 from astropy import units as u
 from astropy.coordinates import SkyCoord
 import linetools.utils as ltu
 
 def data_path(filename):
-    data_dir = resource_filename('linetools', 'data/tests/')
+    data_dir = str(importlib_resources.files('linetools.data.tests'))
     return os.path.join(data_dir, filename)
 
 def test_compare_stuff():


### PR DESCRIPTION
As titled, `pkg_resources` has been deprecated for some time and finally broken in Python 3.12. This PR also rids the `frb` repository of some errors related to the `linetools` dependency.