### PR TITLE
Radec utility string that points to a visibility plot 

### DIFF
--- a/linetools/scripts/lt_radec.py
+++ b/linetools/scripts/lt_radec.py
@@ -36,12 +36,15 @@ def main(args=None):
         return
     # Setup
     from linetools import utils as ltu
-    from .utils import coord_arg_to_coord
+    from .utils import coord_arg_to_coord, get_today_str
     from astropy import units as u
 
     # RA, DEC
     icoord = coord_arg_to_coord(pargs.inp)
     coord = ltu.radec_to_coord(icoord, gal=pargs.gal)
+
+    # today string
+    today = get_today_str()
 
     # Time to print
     print('      ')
@@ -57,6 +60,8 @@ def main(args=None):
     print('SDSS chart: https://skyserver.sdss.org/dr14/en/tools/chart/navi.aspx?ra={:f}&dec={:f}&opt='.format(coord.icrs.ra.deg, coord.icrs.dec.deg))
     print('LEGACY chart: https://www.legacysurvey.org/viewer?ra={:f}&dec={:f}&layer=ls-dr9&zoom=15'.format(coord.icrs.ra.deg, coord.icrs.dec.deg))
     print('LEGACY chart (mark): https://www.legacysurvey.org/viewer?ra={:f}&dec={:f}&layer=ls-dr9&zoom=15&mark={:f},{:f}'.format(coord.icrs.ra.deg, coord.icrs.dec.deg, coord.icrs.ra.deg, coord.icrs.dec.deg))
+    print('Visibility (airmass.org): https://airmass.org/chart/obsid:lco/date:{:s}/object:J{:s}{:s}/ra:{:f}/dec:{:f}\n   (do not forget to update the date and observatory location in the website itself!)'.format(today, coord.icrs.ra.to_string(unit=u.hour,sep='',pad=True),
+                             coord.icrs.dec.to_string(sep='',pad=True,alwayssign=True),coord.icrs.ra.deg, coord.icrs.dec.deg))
 
 if __name__ == '__main__':
     main()

--- a/linetools/scripts/utils.py
+++ b/linetools/scripts/utils.py
@@ -31,3 +31,19 @@ def coord_arg_to_coord(carg):
         icoord = carg
     # Return
     return icoord
+
+
+def get_today_str():
+    """Returns a string representation of current day
+    format YYYY-MM-DD"""
+    import time
+    t = time.gmtime()
+    year = str(t.tm_year)
+    month = str(t.tm_mon)
+    day = str(t.tm_mday)
+    if len(month) == 1:
+        month = '0' + month
+    if len(day) == 1:
+        day = '0' + day
+    s = '{}-{}-{}'.format(year, month, day)
+    return s


### PR DESCRIPTION
Radec utility string that points to a visibility plot -- it adds to the convenience strings already available. The default site is LCO and the default day is today, so the user must update these two manually on the website itself. A warning on this is added. 